### PR TITLE
Update deployment procedure/documentation

### DIFF
--- a/doc/DEPLOYMENT.md
+++ b/doc/DEPLOYMENT.md
@@ -80,7 +80,7 @@ First, we will setup KMS and CodeCommit with the *kms-codecommit* Terraform modu
 - `terraform init`
 - `cp your-vars.tfvars.example $DEPLOYMENT_NAME.tfvars`
 - Update *deployment-name.tfvars* based on the templated values
-- `awsudo $ADMIN_ARN terraform apply -var-file=$DEPLOYMENT_NAME.tfvars -auto-approve`
+- `awsudo -d 3600 $ADMIN_ARN terraform apply -var-file=$DEPLOYMENT_NAME.tfvars -auto-approve`
 
 A file named **_.sops.yaml_** will have been produced, and this will be used in the new CodeCommit repository for appropriate encryption with [sops](https://github.com/mozilla/sops) later in this procedure.
 
@@ -92,7 +92,7 @@ Next, we will configure and deploy an EKS cluster and supporting resources neede
 - `terraform init`
 - `cp your-cluster.tfvars.template to $DEPLOYMENT_NAME.tfvars`
 - Update *deployment-name.tfvars* based on the templated values
-- `awsudo $ADMIN_ARN terraform apply -var-file=$DEPLOYMENT_NAME.tfvars -auto-approve` (this will take a while...)
+- `awsudo -d 3600 $ADMIN_ARN terraform apply -var-file=$DEPLOYMENT_NAME.tfvars -auto-approve` (this will take a while...)
 
 Finally, configure the local environment for the EKS cluster:
 

--- a/doc/DEPLOYMENT.md
+++ b/doc/DEPLOYMENT.md
@@ -172,12 +172,12 @@ Finally, commit and push the changes to the repository:
 
 ### Deploying JupyterHub to the EKS cluster via helm
 
-- `aws eks update-kubeconfig --name $DEPLOYMENT_NAME --region us-east-1 --role-arn $ADMIN_ARN`
+- `awsudo $ADMIN_ARN aws eks update-kubeconfig --name $DEPLOYMENT_NAME --region us-east-1 --role-arn $ADMIN_ARN`
 - Change directories to the top level of the jupyterhub-deploy clone
 - `./tools/deploy $DEPLOYMENT_NAME $ACCOUNT_ID <secrets-yaml> <environment>`
   - environment - staging or prod
   - secrets-yaml - *secrets/deployments/<deployment-name>/secrets/<environment>.yaml*
-- `kubectl -n $DEPLOYMENT_NAME-staging get svc proxy-public`
+- `kubectl get svc proxy-public`
 
 The second command will output the hub's ingress, indicated by "EXTERNAL-IP".
 

--- a/doc/DEPLOYMENT.md
+++ b/doc/DEPLOYMENT.md
@@ -61,8 +61,8 @@ Installing JupyterHub requires working through a flow of several git repositorie
 To make things more convient for the rest of this procedure, set a few evironment variables.  This will reduce the need to modify copy/paste commands.
 
 - `export ADMIN_ARN=arn:aws:iam::<account-id>:role/jupyterhub-admin`
-- `export ACCOUNT_ID=account-id
-- `export DEPLOYMENT_NAME=deployment-name
+- `export ACCOUNT_ID=account-id`
+- `export DEPLOYMENT_NAME=deployment-name`
 
 # Terraform-deploy
 

--- a/doc/DEPLOYMENT.md
+++ b/doc/DEPLOYMENT.md
@@ -92,7 +92,7 @@ Next, we will configure and deploy an EKS cluster and supporting resources neede
 - `terraform init`
 - `cp your-cluster.tfvars.template to $DEPLOYMENT_NAME.tfvars`
 - Update *deployment-name.tfvars* based on the templated values
-- `awsudo $ADMIN_ARN ./mktags`
+- `awsudo $ADMIN_ARN ./mktags` (Need to edit this first; maybe be Terraformed in the future)
 - `awsudo -d 3600 $ADMIN_ARN terraform apply -var-file=$DEPLOYMENT_NAME.tfvars -auto-approve` (this will take a while...)
 
 Finally, configure the local environment for the EKS cluster:

--- a/doc/DEPLOYMENT.md
+++ b/doc/DEPLOYMENT.md
@@ -37,6 +37,8 @@ Use the AWS EC2 Console to create a CI node where you'll deploy from.  The EC2 i
 - From withing the ST network, connect to your CI node using ssh.  You can find your EC2 instance in the AWS console and copy the public IPv4 address, then issue this command:
   - `ssh ec2-user@<public-IPv4-address-for-you-ci-node>`
 
+**attach the worker sg to your CI-node to give it access to the EKS Private API endpoint needed for Terraform to complete normally.***
+
 **_Please remember to shut down the instance when not in use._**
 
 # Start Docker

--- a/doc/DEPLOYMENT.md
+++ b/doc/DEPLOYMENT.md
@@ -66,9 +66,21 @@ To make things more convient for the rest of this procedure, set an evironment v
 
 - `export ADMIN_ARN=arn:aws:iam::<account-id>:role/jupyterhub-admin`
 
+### Setup CodeCommit repository for secrets and an ECR repository for Docker images
+
+First, we will setup KMS and CodeCommit with the *kms-codecommit* Terraform module:
+
+- `cd terraform-deploy/kms-codecommit`
+- `terraform init`
+- `cp your-vars.tfvars.example <deployment-name>.tfvars`
+- Update *deployment-name.tfvars* based on the templated values
+- `awsudo $ADMIN_ARN terraform apply -var-file=deployment-name.tfvars -auto-approve`
+
+A file named **_.sops.yaml_** will have been produced, and this will be used in the new CodeCommit repository for appropriate encryption with [sops](https://github.com/mozilla/sops) later in this procedure.
+
 ### Provision EKS cluster
 
-First, we will configure and deploy an EKS cluster and supporting resources needed to run JupyterHub with the *aws* Terraform module:
+Next, we will configure and deploy an EKS cluster and supporting resources needed to run JupyterHub with the *aws* Terraform module:
 
 - `../aws`
 - `terraform init`
@@ -79,18 +91,6 @@ First, we will configure and deploy an EKS cluster and supporting resources need
 Finally, configure the local environment for the EKS cluster:
 
 - `awsudo $ADMIN_ARN aws eks update-kubeconfig --name <deployment-name>`
-
-### Setup CodeCommit repository for secrets and an ECR repository for Docker images
-
-Next, we will setup KMS and CodeCommit with the *kms-codecommit* Terraform module:
-
-- `cd terraform-deploy/kms-codecommit`
-- `terraform init`
-- `cp your-vars.tfvars.example <deployment-name>.tfvars`
-- Update *deployment-name.tfvars* based on the templated values
-- `awsudo $ADMIN_ARN terraform apply -var-file=deployment-name.tfvars -auto-approve`
-
-A file named **_.sops.yaml_** will have been produced, and this will be used in the new CodeCommit repository for appropriate encryption with [sops](https://github.com/mozilla/sops) later in this procedure.
 
 # Jupyterhub-deploy
 

--- a/doc/DEPLOYMENT.md
+++ b/doc/DEPLOYMENT.md
@@ -94,7 +94,7 @@ Finally, configure the local environment for the EKS cluster:
 
 # Jupyterhub-deploy
 
-In this section, we will define a Docker image and EKS cluster configuration, as well as build and push the image to ECR.  We will then deploy JupyterHub to the cluster.
+In this section, we will define a Docker image, then build and push it to ECR.  We will then deploy JupyterHub to the EKS cluster.
 
 To get started, clone the repository:
 
@@ -102,17 +102,17 @@ To get started, clone the repository:
 
 ### Configure, build, and push a Docker image to ECR
 
-First, identify an existing deployment in the *deployments* directory that most closely matches your desired configuration, and do a recursive copy using `cp -r` (the copied directory name should be the new deployment name).  Modifications to the Docker image and cluster configuration will need to be made.  Follow these instructions:
+First, identify an existing deployment in the *deployments* directory that most closely matches your desired configuration, and do a recursive copy using `cp -r <existing-dir> <new-dir>` (the destination directory name should be the new deployment name).  Modifications to the Docker image and cluster configuration will need to be made.  Follow these instructions:
 
 - Go through the *image* directory, change file names and edit files that contain deployment-specific references.  Also make any changes to the Docker image files as needed (for instance, required software).
 - A file named *common.yaml* file needs to be created in the *config* directory.  An example can be found [here](https://github.com/spacetelescope/jupyterhub-deploy/blob/staging/doc/example-common.yaml).  Place a copy of this example file in *config*, and edit the contents as appropriate.
-- Add, commit, and push all changes.
+- Git add, commit, and push all changes.
 
 Now, we'll build and push the Docker image:
 
-- `cd deployments/<deployment-name>/image`
+- From the top level of the jupyterhub-deploy clone, `cd deployments/<deployment-name>/image`
 - `docker build --tag <account-id>.dkr.ecr.us-east-1.amazonaws.com/<deployment-name>-user-image .`
-- `DOCKER_LOGIN_CMD=$(awsudo arn:aws:iam::<account-id>:role/<deployment-name>-hubploy-ecr aws ecr get-login --region us-east-1 --no-include-email)`
+- `DOCKER_LOGIN_CMD=$(awsudo $ADMIN_ARN aws ecr get-login --region us-east-1 --no-include-email)`
 - `eval $DOCKER_LOGIN_CMD`
 - `docker push <account-id>.dkr.ecr.us-east-1.amazonaws.com/<deployment-name>-user-image:latest`
 

--- a/doc/DEPLOYMENT.md
+++ b/doc/DEPLOYMENT.md
@@ -88,7 +88,7 @@ Next, we will configure and deploy an EKS cluster and supporting resources neede
 - `terraform init`
 - `cp your-cluster.tfvars.template to <deployment-name>.tfvars`
 - Update *deployment-name.tfvars* based on the templated values
-- `awsudo $ADMIN_ARN -var-file=<deployment-name>.tfvars -auto-approve` (this will take a while...)
+- `awsudo $ADMIN_ARN terraform apply -var-file=<deployment-name>.tfvars -auto-approve` (this will take a while...)
 
 Finally, configure the local environment for the EKS cluster:
 

--- a/doc/DEPLOYMENT.md
+++ b/doc/DEPLOYMENT.md
@@ -40,21 +40,6 @@ Note: some of this may change when we move to the sandbox account.
 
 **_Please remember to shut down the instance when not in use._**
 
-# Configure AWS
-
-You will need security credentials.  Under **IAM → Users→ yourUsername → Security Credentials → Access Keys** in the AWS console, create a new set.  Save these credentials, as you will not be able to access your secret key again.
-
-On your CI node, execute:
-
-- `aws configure`
-
-You will be prompted for the following information:
-
-- Access Key ID: **your-key-id**
-- Secret Access Key: **your-access-key**
-- Region: **us-east-1**
-- Default output format: **json**
-
 # Start Docker
 
 `sudo service docker start`
@@ -78,21 +63,12 @@ Get a copy of the repository with this command:
 
 - `git clone --recursive https://github.com/spacetelescope/terraform-deploy`
 
-The terraform-deploy repository has two subdirectories with independent Terraform modules: *aws-creds* and *aws*.  *aws-codecommit-secrets* is a separate repository and will become a third subdirectory after being cloned.
-
 ### Setup IAM resources, KMS, and CodeCommit
 
-The **_aws-creds_** subdirectory contains configuration files to set up roles and policies needed to do the overall deployment.
 
-**Note:** AWS has a hard limit of 10 groups per user. Since terraform-deploy adds 2 groups, you can be a member of at most 8 groups before proceeding.
+==========
 
-Complete these steps:
 
-- `cd aws-creds`
-- `cp roles.tfvars.template roles.tfvars`
-- Customize *roles.tfvars* with your deployment name
-- `terraform init`
-- `terraform apply -var-file=roles.tfvars`
 
 **_aws-codecommit-secrets_** contains Terraform modules to setup a secure way to store secret YAML files for use with helm.  There are two subdirectories in this repository: *kms-codecommit* and *terraform_iam*.
 

--- a/doc/DEPLOYMENT.md
+++ b/doc/DEPLOYMENT.md
@@ -92,6 +92,7 @@ Next, we will configure and deploy an EKS cluster and supporting resources neede
 - `terraform init`
 - `cp your-cluster.tfvars.template to $DEPLOYMENT_NAME.tfvars`
 - Update *deployment-name.tfvars* based on the templated values
+- `awsudo $ADMIN_ARN ./mktags`
 - `awsudo -d 3600 $ADMIN_ARN terraform apply -var-file=$DEPLOYMENT_NAME.tfvars -auto-approve` (this will take a while...)
 
 Finally, configure the local environment for the EKS cluster:

--- a/doc/DEPLOYMENT.md
+++ b/doc/DEPLOYMENT.md
@@ -66,21 +66,9 @@ To make things more convient for the rest of this procedure, set an evironment v
 
 - `export ADMIN_ARN=arn:aws:iam::<account-id>:role/jupyterhub-admin`
 
-### Setup CodeCommit repository for secrets and an ECR repository for Docker images
-
-First, we will setup KMS and CodeCommit with the *kms-codecommit* Terraform module:
-
-- `cd terraform-deploy/kms-codecommit`
-- `terraform init`
-- `cp your-vars.tfvars.example <deployment-name>.tfvars`
-- Update *deployment-name.tfvars* based on the templated values
-- `awsudo $ADMIN_ARN terraform apply -var-file=deployment-name.tfvars -auto-approve`
-
-A file named **_.sops.yaml_** will have been produced, and this will be used in the new CodeCommit repository for appropriate encryption with [sops](https://github.com/mozilla/sops) later in this procedure.
-
 ### Provision EKS cluster
 
-Next, we will configure and deploy an EKS cluster and supporting resources needed to run JupyterHub with the *aws* Terraform module:
+First, we will configure and deploy an EKS cluster and supporting resources needed to run JupyterHub with the *aws* Terraform module:
 
 - `../aws`
 - `terraform init`
@@ -91,6 +79,18 @@ Next, we will configure and deploy an EKS cluster and supporting resources neede
 Finally, configure the local environment for the EKS cluster:
 
 - `awsudo $ADMIN_ARN aws eks update-kubeconfig --name <deployment-name>`
+
+### Setup CodeCommit repository for secrets and an ECR repository for Docker images
+
+Next, we will setup KMS and CodeCommit with the *kms-codecommit* Terraform module:
+
+- `cd terraform-deploy/kms-codecommit`
+- `terraform init`
+- `cp your-vars.tfvars.example <deployment-name>.tfvars`
+- Update *deployment-name.tfvars* based on the templated values
+- `awsudo $ADMIN_ARN terraform apply -var-file=deployment-name.tfvars -auto-approve`
+
+A file named **_.sops.yaml_** will have been produced, and this will be used in the new CodeCommit repository for appropriate encryption with [sops](https://github.com/mozilla/sops) later in this procedure.
 
 # Jupyterhub-deploy
 

--- a/doc/DEPLOYMENT.md
+++ b/doc/DEPLOYMENT.md
@@ -60,8 +60,8 @@ Installing JupyterHub requires working through a flow of several git repositorie
 
 To make things more convient for the rest of this procedure, set a few evironment variables.  This will reduce the need to modify copy/paste commands.
 
-- `export ADMIN_ARN=arn:aws:iam::<account-id>:role/jupyterhub-admin`
 - `export ACCOUNT_ID=account-id`
+- `export ADMIN_ARN=arn:aws:iam::${ACCOUN_ID}:role/jupyterhub-admin`
 - `export DEPLOYMENT_NAME=deployment-name`
 
 # Terraform-deploy

--- a/doc/DEPLOYMENT.md
+++ b/doc/DEPLOYMENT.md
@@ -58,11 +58,11 @@ Installing JupyterHub requires working through a flow of several git repositorie
 
 # Set some convenience variables
 
-To make things more convient for the rest of this procedure, set a few evironment variables.  This will reduce the need to modify copy/paste commands
+To make things more convient for the rest of this procedure, set a few evironment variables.  This will reduce the need to modify copy/paste commands.
 
 - `export ADMIN_ARN=arn:aws:iam::<account-id>:role/jupyterhub-admin`
-- `export ACCOUNT_ID=<account-id>
-- `export DEPLOYMENT_NAME=<deployment-name>
+- `export ACCOUNT_ID=account-id
+- `export DEPLOYMENT_NAME=deployment-name
 
 # Terraform-deploy
 


### PR DESCRIPTION
This is the last (probably imperfect) iteration of docs incorporating what's in the terraform-deploy integration branch.

NOTE: this lacks instructions for creating/applying security groups, that will come next.