### PR TITLE
Automatic ECR scan developer report on push.

### DIFF
--- a/derived-env
+++ b/derived-env
@@ -5,14 +5,10 @@
 
 if [[ "$PERSONAL_IMAGE" == "1" ]]; then
     # Standalone JupyterLab setup,  no ECR scanning
-    ACCOUNT="personal_image"
-    export IMAGE_WAIT_FOR_ECR_SCAN="0"
+    ACCOUNT="standalone_jupyterlab"
 else
     # Octarine AWS JupyterHub setup
     export ACCOUNT=${ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com
-    export IMAGE_WAIT_FOR_ECR_SCAN="1"
-    export IMAGE_UBUNTU_NAME="Focal"
-    export IMAGE_VULNERABILITY_LEVEL="medium"
 fi
 
 export JUPYTERHUB_DIR=`pwd`

--- a/derived-env
+++ b/derived-env
@@ -1,0 +1,31 @@
+#! /bin/bash -eu
+
+# ----------------- derived inputs, nominally don't change --------------
+# automatically sourced into setup-env
+
+if [[ "$PERSONAL_IMAGE" == "1" ]]; then
+    # Standalone JupyterLab setup,  no ECR scanning
+    ACCOUNT="personal_image"
+    export IMAGE_WAIT_FOR_ECR_SCAN="0"
+else
+    # Octarine AWS JupyterHub setup
+    export ACCOUNT=${ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com
+    export IMAGE_WAIT_FOR_ECR_SCAN="1"
+    export IMAGE_UBUNTU_NAME="Focal"
+    export IMAGE_VULNERABILITY_LEVEL="medium"
+fi
+
+export JUPYTERHUB_DIR=`pwd`
+
+export IMAGE_REPO=${DEPLOYMENT_NAME}-user-image
+export COMMON_REPO=${IMAGE_REPO}
+
+export ADMIN_ARN=arn:aws:iam::${ACCOUNT_ID}:role/${ADMIN_ROLENAME}
+
+export COMMON_DIR=`pwd`/deployments/common/image
+export COMMON_ID=${ACCOUNT}/${COMMON_REPO}:${COMMON_TAG}
+
+export IMAGE_DIR=`pwd`/deployments/${DEPLOYMENT_NAME}/image
+export IMAGE_ID=${ACCOUNT}/${IMAGE_REPO}:${IMAGE_TAG}
+
+export PATH="`pwd`/tools":${PATH}

--- a/setup-env.template
+++ b/setup-env.template
@@ -9,32 +9,21 @@
 export ACCOUNT_ID=12345678
 export ADMIN_ROLENAME=admin-role
 export DEPLOYMENT_NAME=cluster-name
-export ENVIRONMENT=staging          # sandbox, dev, test, ops vs. staging and prod?
 export IMAGE_TAG=mission-latest
 export COMMON_TAG=common-latest
-export USE_FROZEN=1                 # use 0 for floating versions,  1 production build from fixed versions.
 
-# ---------------------------------------------------------
+# sandbox, dev, test, ops vs. staging and prod?
+export ENVIRONMENT=staging
+
+# use 0 for loosely pinned package versions,  1 production build from fixed versions.
+export USE_FROZEN=1
+
+# Set to 1 for e.g. personal laptop build
+export PERSONAL_IMAGE=0
 
 # Additional parameters for image-exec Docker run command, e.g. add mounts here
 export IMAGE_RUN_PARS="--rm -p 8888:8888 -it"
 
-export ACCOUNT=${ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com
-# ACCOUNT="xxxxx"
+# ----------------- values derived from basic inputs ---------------------
 
-# ----------------- derived inputs, nominally don't change --------------
-
-export JUPYTERHUB_DIR=`pwd`
-
-export IMAGE_REPO=${DEPLOYMENT_NAME}-user-image
-export COMMON_REPO=${IMAGE_REPO}
-
-export ADMIN_ARN=arn:aws:iam::${ACCOUNT_ID}:role/${ADMIN_ROLENAME}
-
-export COMMON_DIR=`pwd`/deployments/common/image
-export COMMON_ID=${ACCOUNT}/${COMMON_REPO}:${COMMON_TAG}
-
-export IMAGE_DIR=`pwd`/deployments/${DEPLOYMENT_NAME}/image
-export IMAGE_ID=${ACCOUNT}/${IMAGE_REPO}:${IMAGE_TAG}
-
-export PATH="`pwd`/tools":${PATH}
+source derived-env

--- a/setup-env.template
+++ b/setup-env.template
@@ -15,6 +15,8 @@ export COMMON_TAG=common-latest
 # sandbox, dev, test, ops vs. staging and prod?
 export ENVIRONMENT=staging
 
+# ----------------- vvvv less frequently changed vvvv -------------------------------
+
 # use 0 for loosely pinned package versions,  1 production build from fixed versions.
 export USE_FROZEN=1
 
@@ -23,6 +25,13 @@ export PERSONAL_IMAGE=0
 
 # Additional parameters for image-exec Docker run command, e.g. add mounts here
 export IMAGE_RUN_PARS="--rm -p 8888:8888 -it"
+
+# Image scanning,  report Ubuntu status for this version of Ubuntu
+export IMAGE_UBUNTU_NAME="Focal"
+
+# Image scanning,  report CVE's at this severity level and  higher
+export IMAGE_VULNERABILITY_LEVEL="medium"
+
 
 # ----------------- values derived from basic inputs ---------------------
 

--- a/tools/image-all
+++ b/tools/image-all
@@ -2,4 +2,4 @@
 
 # Build, test, and push the image defined by the environment.
 
-image-build  && image-test && image-push && echo "********** Image pipeline succeeded. **********" || echo "!!!!!!!!!!! Image pipeline failed. !!!!!!!!!!!!"
+image-build  && image-test && image-push && image-scan && echo "********** Image pipeline succeeded. **********" || echo "!!!!!!!!!!! Image pipeline failed. !!!!!!!!!!!!"

--- a/tools/image-push
+++ b/tools/image-push
@@ -10,7 +10,3 @@ image-login
 
 echo "================================== Pushing ${IMAGE_ID} =============================="
 docker push ${IMAGE_ID}
-
-if [[ ${IMAGE_WAIT_FOR_ECR_SCAN} == "1" ]]; then
-    image-scan
-fi

--- a/tools/image-push
+++ b/tools/image-push
@@ -8,4 +8,9 @@ image-login
 
 # docker push ${COMMON_ID}
 
+echo "================================== Pushing ${IMAGE_ID} =============================="
 docker push ${IMAGE_ID}
+
+if [[ ${IMAGE_WAIT_FOR_ECR_SCAN} == "1" ]]; then
+    image-scan
+fi

--- a/tools/image-scan
+++ b/tools/image-scan
@@ -1,0 +1,7 @@
+#! /bin/bash -eu
+echo "============================== ECR Docker Image Vulnerability Scan ============================="
+cd  $JUPYTERHUB_DIR
+image-scan-report "$IMAGE_UBUNTU_NAME" $IMAGE_VULNERABILITY_LEVEL >ecr-scan-report.yaml
+
+echo "============================== ECR Scan Summary ================================"
+image-scan-summary report.yaml

--- a/tools/image-scan-report
+++ b/tools/image-scan-report
@@ -29,6 +29,9 @@ image_repo=os.environ["IMAGE_REPO"]
 image_tag=os.environ["IMAGE_TAG"]
 
 def get_scan_results():
+    """Issue an AWS command to dump the ECR scan results as JSON, load the
+    JSON,  and return the resulting dict.
+    """
     scan_results = subprocess.check_output((
         f"awsudo -d 3600 {admin_arn}  aws ecr describe-image-scan-findings "
         f"--no-paginate "
@@ -37,9 +40,15 @@ def get_scan_results():
     return json.loads(scan_results)
 
 def limit_levels(version, levels, full_results):
+    """Only keep findings with statuses in `levels`.  Assume `full_results` contains
+    everything returned from ECR which e.g. **may** include LOW or INFORMATIONAL CVE's
+    which are normally ignored when scanning for MEDIUM and higher;  remove lower
+    priority CVS's from return dict.
+    """
     reduced_results = copy.deepcopy(full_results)
     findings  = reduced_results["imageScanFindings"]["findings"]
     reduced_results["imageScanFindings"]["findings"] = []
+    reduced_results["overall_status"] = "FAILED"
     for finding in findings:
         if finding["severity"] in levels or "ALL" in levels:
             reduced_results["imageScanFindings"]["findings"].append(finding)
@@ -51,6 +60,8 @@ def limit_levels(version, levels, full_results):
                                         ubuntu_status
             else:
                 print("Unknown CVE URI:", uri)
+        if finding["severity"] in FAIL_LEVELS:
+            reduced_results["overall_status"] = "FAILED"
     return reduced_results
 
 KEEP_LEVELS = {
@@ -62,7 +73,15 @@ KEEP_LEVELS = {
     "ALL" : ["CRITICAL", "HIGH", "MEDIUM", "LOW", "INFORMATIONAL"],
 }
 
+FAIL_LEVELS = [
+    "CRITCAL", "HIGH"
+]
+
 def get_report_dict(version, levels):
+    """Get the overall scan report dict which includes both ECR findings which
+    have severities in `levels` and the Ubuntu status string for the CVE for
+    Ubuntu `version`.
+    """
     print("Fetching ECR vulnerability scan",file=sys.stderr)
     sys.stderr.flush()
     vulnerabilities = get_scan_results()
@@ -76,6 +95,11 @@ def get_report_dict(version, levels):
     return reduced
 
 def fetch_ubuntu_uri_status(uri, version_name):
+    """Follow the Ubuntu `uri` included in ECR output for each CVE.  Rip the
+    status for Ubuntu which includes substring `version_name` in its table
+    entry and return a summary string which shows Ubuntu's status on addressing
+    / remediating the CVE.
+    """
     response = requests.get(uri)
     soup = bs4.BeautifulSoup(response.text, "lxml")
     for row in soup.find_all("tr"):
@@ -96,6 +120,9 @@ def main():
     levels = KEEP_LEVELS[sys.argv[2].upper()]
     reduced = get_report_dict(version, levels)
     print(yaml.dump(reduced))
+    if reduced["overall_status"] == "FAILED":
+        return 1
+    return 0
 
 if __name__ == "__main__":
     main()

--- a/tools/image-scan-report
+++ b/tools/image-scan-report
@@ -63,7 +63,15 @@ KEEP_LEVELS = {
 }
 
 def get_report_dict(version, levels):
+    print("Fetching ECR vulnerability scan",file=sys.stderr)
+    sys.stderr.flush()
     vulnerabilities = get_scan_results()
+    while vulnerabilities["imageScanStatus"]["status"] != "COMPLETE":
+        print("Waiting for ECR scan,  prior status:",
+              vulnerabilities["imageScanStatus"]["status"], file=sys.stderr)
+        sys.stderr.flush()
+        time.sleep(10)
+        vulnerabilities = get_scan_results()
     reduced = limit_levels(version, levels, vulnerabilities)
     return reduced
 


### PR DESCRIPTION
Added wait for ECR scan,  automatic report and summary to image-push.

This  both captures the AWS scan output as a YAML file and follows up by checking CVE status with Ubuntu to see if there are any fixes available,   also added to the YAML.

Refactored setup-env.template into setup-env.template and derived-env to make it simpler to configure and add to environment without forcing dev env updates.   The part unlikely to change is in derived-env.

Also added "personal build" mode for e.g. doing laptop builds by setting PERSONAL_IMAGE=1.  Untested.

Submitting for next sprint integration.

