### PR TITLE
Increase memory allocation in roman deployment.

### DIFF
--- a/deployments/jmiller-hub/config/common.yaml
+++ b/deployments/jmiller-hub/config/common.yaml
@@ -29,8 +29,8 @@ jupyterhub:
         CRDS_SERVER_URL: https://jwst-crds.stsci.edu
     defaultUrl: "/lab"
     memory:
-      guarantee: 512M
-      limit: 1G
+      guarantee: 8G
+      limit: 15G
   auth:
     users:
       - add-me@stsci.edu

--- a/deployments/roman/config/common.yaml
+++ b/deployments/roman/config/common.yaml
@@ -33,12 +33,11 @@ jupyterhub:
         CRDS_SERVER_URL: https://jwst-crds.stsci.edu
     defaultUrl: "/lab"
     memory:
-      guarantee: 512M
-      limit: 1G
+      guarantee: 8G
+      limit: 15G
   auth:
     users:
       - add-me@stsci.edu
     admin:
       users:
          - add-me@stsci.edu
-


### PR DESCRIPTION
Updated memory allocations in roman and jmiller-hub deployments to 8G guaranteed 15G limit so JWST cal tests (standing in for Roman) pass.