### PR TITLE
make sure user storage is from EFS

### DIFF
--- a/deployments/roman/config/common.yaml
+++ b/deployments/roman/config/common.yaml
@@ -23,6 +23,9 @@ jupyterhub:
     image:
       tag: dev
       pullPolicy: Always
+    storage:
+      dynamic:
+        storageClass: "aws-efs"
     lifecycleHooks:
       postStart:
         exec:

--- a/doc/example-common.yaml
+++ b/doc/example-common.yaml
@@ -5,6 +5,9 @@ jupyterhub:
   singleuser:
     image:
       tag: staging
+    storage:
+      dynamic:
+        storageClass: "aws-efs"
     lifecycleHooks:
       postStart:
         exec:


### PR DESCRIPTION
Foundational to our setup but overlooked - this is crucial for more than just AMI rotation, also users need to be able to be scheduled on the correct nodes.