### PR TITLE
Default kernels, kernel names, Roman and  TESS image updates, image scanning bugfixes

### DIFF
--- a/deployments/common/image/Dockerfile
+++ b/deployments/common/image/Dockerfile
@@ -4,7 +4,7 @@
 # https://hub.docker.com/_/buildpack-deps/
 # FROM buildpack-deps:focal-scm AS build
 
-FROM jupyter/scipy-notebook:42f4c82a07ff
+FROM jupyter/scipy-notebook:399cbb986c6b
 
 # ------------------------------------------------------------------------
 
@@ -85,7 +85,10 @@ RUN    apt-get update --yes && \
         cm-super \
         libxpa-dev \
         libxt-dev \
+        libbz2-dev \
+        libcudart10.1 \
         && \
+    apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # ------------------------------------------------------------------------
@@ -154,4 +157,3 @@ RUN /opt/common-scripts/install-common ds9
 # Set up astroquery and ds9 desktop short-cut, will be further
 # augmented by specific deployments
 COPY default-home-contents/   /etc/default-home-contents
-

--- a/deployments/common/image/Dockerfile.trailer
+++ b/deployments/common/image/Dockerfile.trailer
@@ -1,18 +1,24 @@
 # ========================= vvvvv Generic vvvvv  =========================
 
+# ----------------------------------------------------------------------
+USER $NB_UID
+RUN /opt/common-scripts/kernel-setup   # set up Ipython / JupyterLab kernels
+
 # As part of Dockerfile.trailer,  these statements are executed from the
 # perspective of the deployment image directory,  not common.
 
 USER root
-
-# Copy everything now that build is complete and cache busting wont occur
-COPY environments/    /opt/environments
 
 # ----------------------------------------------------------------------
 
 # remove this step once nbgitpuller enabled; these contents will be in the
 #  jupyterhub-user-content repo.   Install deployment-specific $HOME files.
 COPY default-home-contents/  /etc/default-home-contents
+RUN  cp -r /home/jovyan/.local  /etc/default-home-contents && \
+     cp -r /home/jovyan/.jupyter /etc/default-home-contents
+COPY global_bashrc  /home/jovyan
+RUN  cat /home/jovyan/global_bashrc   >> /etc/bash.bashrc  && \
+     rm /home/jovyan/global_bashrc
 
 # Fix certs in conda for application level SSL, e.g. pass image-test running on CI-node
 RUN /opt/common-scripts/fix-certs
@@ -22,6 +28,15 @@ RUN /opt/common-scripts/fix-certs
 RUN cp -r /etc/default-home-contents/* /home/jovyan && \
     fix-permissions  /home/jovyan  &&\
     fix-permissions  /opt/environments
+
+# This top level command runs unit tests for the image,  nominally import tests
+# and notebook runs but it's an arbitrary bash script.
+COPY environments/test    /opt/environments/test
+
+# Install security patches now that build is complete;  potentially this could be done sooner
+RUN apt-get update && \
+    apt-get dist-upgrade --yes && \
+    apt-get clean
 
 USER $NB_USER
 WORKDIR /home/$NB_USER

--- a/deployments/common/image/base.yml
+++ b/deployments/common/image/base.yml
@@ -3,11 +3,10 @@ channels:
   - conda-forge
   - http://ssb.stsci.edu/astroconda
 dependencies:
+  - cfitsio
   - jupyterhub
   - jupyterlab
   - nodejs
-  - nb_conda_kernels
-  - nb_conda
   - ipykernel
   - ipyevents
   # For Jupyter Desktop Proxy
@@ -17,3 +16,6 @@ dependencies:
     - jupyter-server-proxy
     - nbgitpuller
     - git+https://github.com/yuvipanda/jupyter-desktop-server@daecbdbbf89003a1d71fa03f362682a886bb3ad7
+
+#  - nb_conda_kernels
+#  - nb_conda

--- a/deployments/common/image/common-scripts/kernel-setup
+++ b/deployments/common/image/common-scripts/kernel-setup
@@ -11,35 +11,34 @@ source /opt/common-scripts/env-activate base
 
 mkdir -p $HOME/.jupyter
 
-if [[ ! -f $HOME/.jupyter/jupyter_config.json  ]]; then
-    cat > $HOME/.jupyter/jupyter_config.json  <<EOF
+cat > $HOME/.jupyter/jupyter_config.json  <<EOF
 {
   "CondaKernelSpecManager": {
-    "kernelspec_path": "--user"
+    "kernelspec_path": "--user",
+    "name_format" : "{environment} -- {display_name}"
   }
 }
 EOF
-else
-    echo "jupyter_config.json has already been installed."
-fi
 
 # Only set up kernels which have actually been installed, e.g. not
 # disabled by Dockerfile edits during debug.
 
-# for kernel in `conda env list | grep -v '#' | grep -v base | cut -d' ' -f1`; do
-# 
-#     echo "================== Adding kernel $kernel ====================="
-# 
-#     source /opt/common-scripts/env-activate $kernel
-# 
-#     python -m ipykernel install --user --name $kernel --display-name "`cat  /opt/environments/${kernel}/kernel.name`"
-# 
-#     source /opt/common-scripts/env-deactivate $kernel
-# 
-# done
+# Potentially among other things,  these are needed so that image-test will run.
 
-echo "nb_kernels:"
-python -m nb_conda_kernels list
+for kernel in `conda env list | grep -v '#' | grep -v base | cut -d' ' -f1`; do
+
+    echo "================== Adding kernel $kernel ====================="
+
+    source /opt/common-scripts/env-activate $kernel
+
+    python -m ipykernel install --user --name $kernel --display-name "`cat  /opt/environments/${kernel}/kernel.name`"
+
+    source /opt/common-scripts/env-deactivate $kernel
+
+done
+
+# echo "nb_kernels:"
+# python -m nb_conda_kernels list
 
 echo "jupyter kernelspecs:"
 jupyter kernelspec list

--- a/deployments/roman/image/Dockerfile
+++ b/deployments/roman/image/Dockerfile
@@ -66,29 +66,28 @@ RUN cd /tmp && \
     make && \
     make install
 
-# ----------------------------------------------------------------------
-USER $NB_UID
-
-RUN /opt/common-scripts/kernel-setup
-
-# RUN jupyter kernelspec list | grep conda\- | awk '{print $1;}' | xargs jupyter kernelspec remove -f
-
 # ========================= ^^^^^ Custom  ^^^^^ =========================
 # ========================= vvvvv Generic vvvvv  =========================
+
+# ----------------------------------------------------------------------
+USER $NB_UID
+RUN /opt/common-scripts/kernel-setup   # set up Ipython / JupyterLab kernels
 
 # As part of Dockerfile.trailer,  these statements are executed from the
 # perspective of the deployment image directory,  not common.
 
 USER root
 
-# Copy everything now that build is complete and cache busting wont occur
-COPY environments/    /opt/environments
-
 # ----------------------------------------------------------------------
 
 # remove this step once nbgitpuller enabled; these contents will be in the
 #  jupyterhub-user-content repo.   Install deployment-specific $HOME files.
 COPY default-home-contents/  /etc/default-home-contents
+RUN  cp -r /home/jovyan/.local  /etc/default-home-contents && \
+     cp -r /home/jovyan/.jupyter /etc/default-home-contents
+COPY global_bashrc  /home/jovyan
+RUN  cat /home/jovyan/global_bashrc   >> /etc/bash.bashrc  && \
+     rm /home/jovyan/global_bashrc
 
 # Fix certs in conda for application level SSL, e.g. pass image-test running on CI-node
 RUN /opt/common-scripts/fix-certs
@@ -98,6 +97,15 @@ RUN /opt/common-scripts/fix-certs
 RUN cp -r /etc/default-home-contents/* /home/jovyan && \
     fix-permissions  /home/jovyan  &&\
     fix-permissions  /opt/environments
+
+# This top level command runs unit tests for the image,  nominally import tests
+# and notebook runs but it's an arbitrary bash script.
+COPY environments/test    /opt/environments/test
+
+# Install security patches now that build is complete;  potentially this could be done sooner
+RUN apt-get update && \
+    apt-get dist-upgrade --yes && \
+    apt-get clean
 
 USER $NB_USER
 WORKDIR /home/$NB_USER

--- a/deployments/roman/image/Dockerfile.custom
+++ b/deployments/roman/image/Dockerfile.custom
@@ -66,11 +66,4 @@ RUN cd /tmp && \
     make && \
     make install
 
-# ----------------------------------------------------------------------
-USER $NB_UID
-
-RUN /opt/common-scripts/kernel-setup
-
-# RUN jupyter kernelspec list | grep conda\- | awk '{print $1;}' | xargs jupyter kernelspec remove -f
-
 # ========================= ^^^^^ Custom  ^^^^^ =========================

--- a/deployments/roman/image/default-home-contents/example-notebooks/jwst_reduction_example.ipynb
+++ b/deployments/roman/image/default-home-contents/example-notebooks/jwst_reduction_example.ipynb
@@ -1125,9 +1125,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "WFIRST",
+   "display_name": "Roman Calibration Pipeline",
    "language": "python",
-   "name": "wfirst-sit"
+   "name": "roman-cal"
   },
   "language_info": {
    "codemirror_mode": {

--- a/deployments/roman/image/environments/cvt/cvt-frozen.yml
+++ b/deployments/roman/image/environments/cvt/cvt-frozen.yml
@@ -1,7 +1,7 @@
 name: cvt
 channels:
+  - manics
   - conda-forge
-  - defaults
 dependencies:
   - _libgcc_mutex=0.1
   - _openmp_mutex=4.5
@@ -13,7 +13,7 @@ dependencies:
   - backports=1.0
   - backports.functools_lru_cache=1.6.1
   - beautifulsoup4=4.9.3
-  - blas=2.2
+  - blas=2.14
   - bleach=3.2.1
   - blinker=1.4
   - blosc=1.20.1
@@ -23,18 +23,20 @@ dependencies:
   - brotlipy=0.7.0
   - brunsli=0.1
   - bzip2=1.0.8
-  - c-ares=1.16.1
-  - ca-certificates=2020.11.8
-  - certifi=2020.11.8
+  - c-ares=1.17.1
+  - ca-certificates=2020.12.5
+  - cached-property=1.5.1
+  - certifi=2020.12.5
   - certipy=0.1.3
-  - cffi=1.14.3
+  - cffi=1.14.4
+  - cfitsio=3.470
   - chardet=3.0.4
   - charls=2.1.0
   - click=7.1.2
   - cloudpickle=1.6.0
   - conda-package-handling=1.7.2
   - configurable-http-proxy=1.3.0
-  - cryptography=3.2.1
+  - cryptography=3.3.1
   - cycler=0.10.0
   - cython=0.29.21
   - cytoolz=0.11.0
@@ -45,23 +47,22 @@ dependencies:
   - dill=0.3.3
   - distributed=2.30.1
   - entrypoints=0.3
-  - fastcache=1.1.0
   - filelock=3.0.12
   - freetype=2.10.4
   - fsspec=0.8.4
   - giflib=5.2.1
   - glob2=0.7
-  - gmp=6.2.0
+  - gmp=6.2.1
   - gmpy2=2.1.0b1
-  - h5py=2.10.0
+  - h5py=3.1.0
   - hdf5=1.10.6
   - heapdict=1.0.1
   - icu=67.1
   - idna=2.10
   - imagecodecs=2020.5.30
   - imageio=2.9.0
-  - importlib-metadata=2.0.0
-  - importlib_metadata=2.0.0
+  - importlib-metadata=3.1.1
+  - importlib_metadata=3.1.1
   - ipyevents=0.8.1
   - ipykernel=5.3.4
   - ipympl=0.5.8
@@ -75,10 +76,10 @@ dependencies:
   - json5=0.9.5
   - jsonschema=3.2.0
   - jupyter_client=6.1.7
-  - jupyter_core=4.6.3
+  - jupyter_core=4.7.0
   - jupyter_telemetry=0.1.0
-  - jupyterhub=1.2.1
-  - jupyterhub-base=1.2.1
+  - jupyterhub=1.2.2
+  - jupyterhub-base=1.2.2
   - jupyterlab=2.2.9
   - jupyterlab_pygments=0.1.2
   - jupyterlab_server=1.2.0
@@ -89,23 +90,24 @@ dependencies:
   - ld_impl_linux-64=2.35.1
   - lerc=2.2
   - libaec=1.0.4
-  - libarchive=3.4.3
-  - libblas=3.9.0
-  - libcblas=3.9.0
+  - libarchive=3.5.0
+  - libblas=3.8.0
+  - libcblas=3.8.0
   - libcurl=7.71.1
   - libedit=3.1.20191231
   - libev=4.33
-  - libffi=3.2.1
+  - libffi=3.3
   - libgcc-ng=9.3.0
   - libgfortran-ng=7.5.0
   - libgfortran4=7.5.0
+  - libgomp=9.3.0
   - libiconv=1.16
-  - liblapack=3.9.0
-  - liblapacke=3.9.0
+  - liblapack=3.8.0
+  - liblapacke=3.8.0
   - liblief=0.10.1
   - libllvm10=10.0.1
   - libnghttp2=1.41.0
-  - libopenblas=0.3.12
+  - libopenblas=0.3.7
   - libpng=1.6.37
   - libprotobuf=3.13.0.1
   - libsodium=1.0.18
@@ -116,30 +118,27 @@ dependencies:
   - libwebp-base=1.1.0
   - libxml2=2.9.10
   - libzopfli=1.0.3
-  - llvm-openmp=11.0.0
   - llvmlite=0.34.0
   - locket=0.2.0
   - lz4-c=1.9.2
   - lzo=2.10
   - mako=1.1.3
   - markupsafe=1.1.1
-  - matplotlib-base=3.3.2
+  - matplotlib-base=3.3.3
   - mistune=0.8.4
   - mock=4.0.2
   - mpc=1.1.0
   - mpfr=4.0.2
   - mpmath=1.1.0
   - msgpack-python=1.0.0
-  - nb_conda=2.2.1
-  - nb_conda_kernels=2.3.0
   - nbclient=0.5.1
   - nbconvert=6.0.7
   - nbformat=5.0.8
   - ncurses=6.2
   - nest-asyncio=1.4.3
   - networkx=2.5
-  - nodejs=15.2.0
-  - notebook=6.1.4
+  - nodejs=12.19.0
+  - notebook=6.1.5
   - numba=0.51.2
   - numexpr=2.7.1
   - numpy=1.19.4
@@ -147,10 +146,10 @@ dependencies:
   - olefile=0.46
   - openjpeg=2.3.1
   - openssl=1.1.1h
-  - packaging=20.4
+  - packaging=20.7
   - pamela=1.0.0
   - pandas=1.1.4
-  - pandoc=2.11.1.1
+  - pandoc=2.11.2
   - pandocfilters=1.4.2
   - parso=0.7.1
   - partd=1.1.0
@@ -159,7 +158,7 @@ dependencies:
   - pexpect=4.8.0
   - pickleshare=0.7.5
   - pillow=8.0.1
-  - pip=20.2.4
+  - pip=20.3.1
   - pkginfo=1.6.1
   - prometheus_client=0.9.0
   - prompt-toolkit=3.0.8
@@ -170,9 +169,9 @@ dependencies:
   - pycosat=0.6.3
   - pycparser=2.20
   - pycurl=7.43.0.6
-  - pygments=2.7.2
+  - pygments=2.7.3
   - pyjwt=1.7.1
-  - pyopenssl=19.1.0
+  - pyopenssl=20.0.0
   - pyparsing=2.4.7
   - pyrsistent=0.17.3
   - pysocks=1.7.1
@@ -205,19 +204,19 @@ dependencies:
   - sortedcontainers=2.3.0
   - soupsieve=2.0.1
   - sqlalchemy=1.3.20
-  - sqlite=3.33.0
+  - sqlite=3.34.0
   - statsmodels=0.12.1
-  - sympy=1.6.2
+  - sympy=1.7
   - tblib=1.6.0
   - terminado=0.9.1
   - testpath=0.4.4
   - threadpoolctl=2.1.0
-  - tifffile=2020.10.1
+  - tifffile=2020.12.8
   - tini=0.18.0
   - tk=8.6.10
   - toolz=0.11.1
   - tornado=6.1
-  - tqdm=4.52.0
+  - tqdm=4.54.1
   - traitlets=5.0.5
   - typing_extensions=3.7.4.3
   - urllib3=1.25.11
@@ -225,7 +224,7 @@ dependencies:
   - wcwidth=0.2.5
   - webencodings=0.5.1
   - websockify=0.9.0
-  - wheel=0.35.1
+  - wheel=0.36.1
   - widgetsnbextension=3.5.1
   - xlrd=1.2.0
   - xz=5.2.5
@@ -243,11 +242,11 @@ dependencies:
     - appdirs==1.4.4
     - astropy-sphinx-theme==1.1
     - async-timeout==3.0.1
-    - awscli==1.18.181
+    - awscli==1.18.194
     - babel==2.9.0
     - black==20.8b1
-    - boto3==1.16.21
-    - botocore==1.19.21
+    - boto3==1.16.34
+    - botocore==1.19.34
     - ci-watson==0.5
     - codecov==2.1.10
     - colorama==0.4.3
@@ -260,7 +259,7 @@ dependencies:
     - jupyter-desktop-server==0.1.2
     - jupyter-server-proxy==1.5.0
     - mccabe==0.6.1
-    - multidict==5.0.2
+    - multidict==5.1.0
     - mypy-extensions==0.4.3
     - nbgitpuller==0.9.0
     - numpydoc==1.1.0

--- a/deployments/roman/image/environments/mirage/mirage-frozen.yml
+++ b/deployments/roman/image/environments/mirage/mirage-frozen.yml
@@ -1,7 +1,7 @@
 name: mirage
 channels:
+  - manics
   - conda-forge
-  - defaults
 dependencies:
   - _libgcc_mutex=0.1
   - _openmp_mutex=4.5
@@ -13,7 +13,7 @@ dependencies:
   - backports=1.0
   - backports.functools_lru_cache=1.6.1
   - beautifulsoup4=4.9.3
-  - blas=2.2
+  - blas=2.14
   - bleach=3.2.1
   - blinker=1.4
   - blosc=1.20.1
@@ -23,18 +23,20 @@ dependencies:
   - brotlipy=0.7.0
   - brunsli=0.1
   - bzip2=1.0.8
-  - c-ares=1.16.1
-  - ca-certificates=2020.11.8
-  - certifi=2020.11.8
+  - c-ares=1.17.1
+  - ca-certificates=2020.12.5
+  - cached-property=1.5.1
+  - certifi=2020.12.5
   - certipy=0.1.3
-  - cffi=1.14.3
+  - cffi=1.14.4
+  - cfitsio=3.470
   - chardet=3.0.4
   - charls=2.1.0
   - click=7.1.2
   - cloudpickle=1.6.0
   - conda-package-handling=1.7.2
   - configurable-http-proxy=1.3.0
-  - cryptography=3.2.1
+  - cryptography=3.3.1
   - cycler=0.10.0
   - cython=0.29.21
   - cytoolz=0.11.0
@@ -45,23 +47,22 @@ dependencies:
   - dill=0.3.3
   - distributed=2.30.1
   - entrypoints=0.3
-  - fastcache=1.1.0
   - filelock=3.0.12
   - freetype=2.10.4
   - fsspec=0.8.4
   - giflib=5.2.1
   - glob2=0.7
-  - gmp=6.2.0
+  - gmp=6.2.1
   - gmpy2=2.1.0b1
-  - h5py=2.10.0
+  - h5py=3.1.0
   - hdf5=1.10.6
   - heapdict=1.0.1
   - icu=67.1
   - idna=2.10
   - imagecodecs=2020.5.30
   - imageio=2.9.0
-  - importlib-metadata=2.0.0
-  - importlib_metadata=2.0.0
+  - importlib-metadata=3.1.1
+  - importlib_metadata=3.1.1
   - ipyevents=0.8.1
   - ipykernel=5.3.4
   - ipympl=0.5.8
@@ -75,10 +76,10 @@ dependencies:
   - json5=0.9.5
   - jsonschema=3.2.0
   - jupyter_client=6.1.7
-  - jupyter_core=4.6.3
+  - jupyter_core=4.7.0
   - jupyter_telemetry=0.1.0
-  - jupyterhub=1.2.1
-  - jupyterhub-base=1.2.1
+  - jupyterhub=1.2.2
+  - jupyterhub-base=1.2.2
   - jupyterlab=2.2.9
   - jupyterlab_pygments=0.1.2
   - jupyterlab_server=1.2.0
@@ -89,23 +90,24 @@ dependencies:
   - ld_impl_linux-64=2.35.1
   - lerc=2.2
   - libaec=1.0.4
-  - libarchive=3.4.3
-  - libblas=3.9.0
-  - libcblas=3.9.0
+  - libarchive=3.5.0
+  - libblas=3.8.0
+  - libcblas=3.8.0
   - libcurl=7.71.1
   - libedit=3.1.20191231
   - libev=4.33
-  - libffi=3.2.1
+  - libffi=3.3
   - libgcc-ng=9.3.0
   - libgfortran-ng=7.5.0
   - libgfortran4=7.5.0
+  - libgomp=9.3.0
   - libiconv=1.16
-  - liblapack=3.9.0
-  - liblapacke=3.9.0
+  - liblapack=3.8.0
+  - liblapacke=3.8.0
   - liblief=0.10.1
   - libllvm10=10.0.1
   - libnghttp2=1.41.0
-  - libopenblas=0.3.12
+  - libopenblas=0.3.7
   - libpng=1.6.37
   - libprotobuf=3.13.0.1
   - libsodium=1.0.18
@@ -116,30 +118,27 @@ dependencies:
   - libwebp-base=1.1.0
   - libxml2=2.9.10
   - libzopfli=1.0.3
-  - llvm-openmp=11.0.0
   - llvmlite=0.34.0
   - locket=0.2.0
   - lz4-c=1.9.2
   - lzo=2.10
   - mako=1.1.3
   - markupsafe=1.1.1
-  - matplotlib-base=3.3.2
+  - matplotlib-base=3.3.3
   - mistune=0.8.4
   - mock=4.0.2
   - mpc=1.1.0
   - mpfr=4.0.2
   - mpmath=1.1.0
   - msgpack-python=1.0.0
-  - nb_conda=2.2.1
-  - nb_conda_kernels=2.3.0
   - nbclient=0.5.1
   - nbconvert=6.0.7
   - nbformat=5.0.8
   - ncurses=6.2
   - nest-asyncio=1.4.3
   - networkx=2.5
-  - nodejs=15.2.0
-  - notebook=6.1.4
+  - nodejs=12.19.0
+  - notebook=6.1.5
   - numba=0.51.2
   - numexpr=2.7.1
   - numpy=1.19.4
@@ -147,10 +146,10 @@ dependencies:
   - olefile=0.46
   - openjpeg=2.3.1
   - openssl=1.1.1h
-  - packaging=20.4
+  - packaging=20.7
   - pamela=1.0.0
   - pandas=1.1.4
-  - pandoc=2.11.1.1
+  - pandoc=2.11.2
   - pandocfilters=1.4.2
   - parso=0.7.1
   - partd=1.1.0
@@ -159,7 +158,7 @@ dependencies:
   - pexpect=4.8.0
   - pickleshare=0.7.5
   - pillow=8.0.1
-  - pip=20.2.4
+  - pip=20.3.1
   - pkginfo=1.6.1
   - prometheus_client=0.9.0
   - prompt-toolkit=3.0.8
@@ -170,9 +169,9 @@ dependencies:
   - pycosat=0.6.3
   - pycparser=2.20
   - pycurl=7.43.0.6
-  - pygments=2.7.2
+  - pygments=2.7.3
   - pyjwt=1.7.1
-  - pyopenssl=19.1.0
+  - pyopenssl=20.0.0
   - pyparsing=2.4.7
   - pyrsistent=0.17.3
   - pysocks=1.7.1
@@ -205,19 +204,19 @@ dependencies:
   - sortedcontainers=2.3.0
   - soupsieve=2.0.1
   - sqlalchemy=1.3.20
-  - sqlite=3.33.0
+  - sqlite=3.34.0
   - statsmodels=0.12.1
-  - sympy=1.6.2
+  - sympy=1.7
   - tblib=1.6.0
   - terminado=0.9.1
   - testpath=0.4.4
   - threadpoolctl=2.1.0
-  - tifffile=2020.10.1
+  - tifffile=2020.12.8
   - tini=0.18.0
   - tk=8.6.10
   - toolz=0.11.1
   - tornado=6.1
-  - tqdm=4.52.0
+  - tqdm=4.54.1
   - traitlets=5.0.5
   - typing_extensions=3.7.4.3
   - urllib3=1.25.11
@@ -225,7 +224,7 @@ dependencies:
   - wcwidth=0.2.5
   - webencodings=0.5.1
   - websockify=0.9.0
-  - wheel=0.35.1
+  - wheel=0.36.1
   - widgetsnbextension=3.5.1
   - xlrd=1.2.0
   - xz=5.2.5
@@ -242,21 +241,21 @@ dependencies:
     - ansiwrap==0.8.4
     - appdirs==1.4.4
     - asdf==2.7.1
-    - astropy==4.1
+    - astropy==4.2
     - astropy-sphinx-theme==1.1
     - astroquery==0.4.1
     - async-timeout==3.0.1
-    - awscli==1.18.180
+    - awscli==1.18.194
     - babel==2.9.0
     - batman-package==2.4.7
     - black==20.8b1
-    - boto3==1.16.20
-    - botocore==1.19.20
+    - boto3==1.16.34
+    - botocore==1.19.34
     - ci-watson==0.5
     - codecov==2.1.10
     - colorama==0.4.3
     - coverage==5.3
-    - crds==10.1.0
+    - crds==10.2
     - docutils==0.15.2
     - drizzle==1.13.1
     - et-xmlfile==1.0.1
@@ -268,7 +267,7 @@ dependencies:
     - imagesize==1.2.0
     - iniconfig==1.1.1
     - jdcal==1.4.1
-    - jeepney==0.5.0
+    - jeepney==0.6.0
     - jmespath==0.10.0
     - jupyter==1.0.0
     - jupyter-console==6.2.0
@@ -278,10 +277,10 @@ dependencies:
     - jwst-backgrounds==1.1.2
     - jwxml==0.3.2
     - keyring==21.5.0
-    - lxml==4.6.1
+    - lxml==4.6.2
     - mccabe==0.6.1
     - mirage==1.3.3
-    - multidict==5.0.2
+    - multidict==5.1.0
     - mypy-extensions==0.4.3
     - nbgitpuller==0.9.0
     - nircam-gsim==1.4b1
@@ -296,19 +295,20 @@ dependencies:
     - py==1.9.0
     - pyasn1==0.4.8
     - pycodestyle==2.6.0
+    - pyerfa==1.7.1.1
     - pyflakes==2.2.0
     - pysiaf==0.10.0
     - pytest==6.1.2
     - pytest-cov==2.10.1
     - pytest-doctestplus==0.8.0
     - pytest-openfiles==0.5.0
-    - qtconsole==4.7.7
+    - qtconsole==5.0.1
     - qtpy==1.9.0
     - regex==2020.11.13
     - requests-mock==1.8.0
     - rsa==4.5
     - s3transfer==0.3.3
-    - secretstorage==3.2.0
+    - secretstorage==3.3.0
     - semantic-version==2.8.5
     - simpervisor==0.3
     - snowballstemmer==2.0.0
@@ -334,7 +334,7 @@ dependencies:
     - tenacity==6.2.0
     - textwrap3==0.9.2
     - toml==0.10.2
-    - tweakwcs==0.6.5
+    - tweakwcs==0.7.0
     - typed-ast==1.4.1
     - webbpsf==0.9.1
     - yarl==1.6.3

--- a/deployments/roman/image/environments/roman-cal/roman-cal-frozen.yml
+++ b/deployments/roman/image/environments/roman-cal/roman-cal-frozen.yml
@@ -1,19 +1,18 @@
 name: roman-cal
 channels:
   - conda-forge
-  - defaults
 dependencies:
   - _libgcc_mutex=0.1
   - _openmp_mutex=4.5
-  - ca-certificates=2020.11.8
-  - certifi=2020.11.8
+  - ca-certificates=2020.12.5
+  - certifi=2020.12.5
   - fftw=3.3.8
   - freetds=1.1.15
   - ld_impl_linux-64=2.35.1
   - libblas=3.9.0
   - libcblas=3.9.0
   - libedit=3.1.20191231
-  - libffi=3.2.1
+  - libffi=3.3
   - libgcc-ng=9.3.0
   - libgfortran-ng=9.3.0
   - libgfortran5=9.3.0
@@ -25,16 +24,16 @@ dependencies:
   - ncurses=6.2
   - numpy=1.19.4
   - openssl=1.1.1h
-  - pip=20.2.4
+  - pip=20.3.1
   - pyfftw=0.12.0
   - python=3.8.6
   - python_abi=3.8
   - readline=8.0
   - setuptools=49.6.0
-  - sqlite=3.33.0
+  - sqlite=3.34.0
   - tk=8.6.10
   - unixodbc=2.3.9
-  - wheel=0.35.1
+  - wheel=0.36.1
   - xz=5.2.5
   - zlib=1.2.11
   - pip:
@@ -43,31 +42,31 @@ dependencies:
     - appdirs==1.4.4
     - asdf==2.7.1
     - asteval==0.9.21
-    - astropy==4.1
+    - astropy==4.2
     - astropy-sphinx-theme==1.1
     - astroquery==0.4.1
     - astroscrappy==1.0.8
     - async-generator==1.10
     - attrs==20.3.0
-    - awscli==1.18.180
+    - awscli==1.18.194
     - babel==2.9.0
     - backcall==0.2.0
     - beautifulsoup4==4.9.3
     - black==20.8b1
     - bleach==3.2.1
     - bokeh==2.2.3
-    - boto3==1.16.20
-    - botocore==1.19.20
+    - boto3==1.16.34
+    - botocore==1.19.34
     - bottleneck==1.3.2
-    - cffi==1.14.3
+    - cffi==1.14.4
     - chardet==3.0.4
     - ci-watson==0.5
     - click==7.1.2
     - codecov==2.1.10
     - colorama==0.4.3
     - coverage==5.3
-    - crds==10.1.0
-    - cryptography==3.2.1
+    - crds==10.2
+    - cryptography==3.3.1
     - cubeviz==0.3.0
     - cycler==0.10.0
     - cython==0.29.21
@@ -87,7 +86,7 @@ dependencies:
     - freetype-py==2.2.0
     - ginga==3.1.0
     - glue-core==1.0.1
-    - glue-vispy-viewers==1.0.1
+    - glue-vispy-viewers==1.0.2
     - gwcs==0.15.0
     - h5py==3.1.0
     - healpy==1.14.0
@@ -101,7 +100,7 @@ dependencies:
     - ipython-genutils==0.2.0
     - jdcal==1.4.1
     - jedi==0.17.2
-    - jeepney==0.5.0
+    - jeepney==0.6.0
     - jinja2==2.11.2
     - jmespath==0.10.0
     - joblib==0.17.0
@@ -118,7 +117,7 @@ dependencies:
     - keyring==21.5.0
     - kiwisolver==1.3.1
     - lockfile==0.12.2
-    - lxml==4.6.1
+    - lxml==4.6.2
     - markupsafe==1.1.1
     - matplotlib==3.3.3
     - mccabe==0.6.1
@@ -133,8 +132,8 @@ dependencies:
     - networkx==2.5
     - numpydoc==1.1.0
     - openpyxl==3.0.5
-    - packaging==20.4
-    - pandas==1.1.4
+    - packaging==20.7
+    - pandas==1.1.5
     - pandeia-engine==1.5.2
     - pandocfilters==1.4.3
     - pandokia==2.3.0
@@ -156,8 +155,9 @@ dependencies:
     - pycodestyle==2.6.0
     - pycparser==2.20
     - pyds9==1.8.1
+    - pyerfa==1.7.1.1
     - pyflakes==2.2.0
-    - pygments==2.7.2
+    - pygments==2.7.3
     - pyopengl==3.1.5
     - pyparsing==2.4.7
     - pyqt5==5.11.3
@@ -177,20 +177,20 @@ dependencies:
     - pywavelets==1.1.1
     - pyyaml==5.3.1
     - pyzmq==20.0.0
-    - qtawesome==1.0.1
-    - qtconsole==4.7.7
+    - qtawesome==1.0.2
+    - qtconsole==5.0.1
     - qtpy==1.9.0
     - radio-beam==0.3.2
     - regex==2020.11.13
     - requests==2.25.0
     - requests-mock==1.8.0
-    - git+https://github.com/spacetelescope/romancal.git
+    - git+https://github.com/spacetelescope/romancal
     - rsa==4.5
     - s3transfer==0.3.3
     - scikit-image==0.17.2
     - scikit-learn==0.23.2
     - scipy==1.5.4
-    - secretstorage==3.2.0
+    - secretstorage==3.3.0
     - semantic-version==2.8.5
     - six==1.15.0
     - snowballstemmer==2.0.0
@@ -212,7 +212,7 @@ dependencies:
     - sphinxcontrib-jsmath==1.0.1
     - sphinxcontrib-qthelp==1.0.3
     - sphinxcontrib-serializinghtml==1.1.4
-    - git+https://github.com/spacetelescope/stdatamodels.git
+    - stdatamodels==0.1.0
     - stsci-image==2.3.3
     - stsci-imagestats==1.6.2
     - stsci-rtd-theme==0.0.2
@@ -224,16 +224,16 @@ dependencies:
     - testpath==0.4.4
     - textwrap3==0.9.2
     - threadpoolctl==2.1.0
-    - tifffile==2020.10.1
+    - tifffile==2020.12.8
     - toml==0.10.2
     - tornado==6.1
-    - tqdm==4.52.0
+    - tqdm==4.54.1
     - traitlets==5.0.5
-    - tweakwcs==0.6.5
+    - tweakwcs==0.7.0
     - typed-ast==1.4.1
     - typing-extensions==3.7.4.3
     - urllib3==1.26.2
-    - vispy==0.6.5
+    - vispy==0.6.6
     - wcwidth==0.2.5
     - webbpsf==0.9.1
     - webencodings==0.5.1

--- a/deployments/roman/image/global_bashrc
+++ b/deployments/roman/image/global_bashrc
@@ -1,0 +1,6 @@
+export PS1="${debian_chroot:+($debian_chroot)}\u@notebook:\w\$ "
+
+# Enable conda and activate jwst-masterclass by default
+. /opt/conda/etc/profile.d/conda.sh
+
+conda activate roman-cal

--- a/deployments/tess/image/Dockerfile
+++ b/deployments/tess/image/Dockerfile
@@ -13,7 +13,8 @@ USER ${NB_UID}
 
 # TESS
 COPY environments/tess/ /opt/environments/tess
-RUN /opt/common-scripts/env-create  tess /opt/environments/tess/tess.yml
+RUN /opt/common-scripts/env-clone  base  tess
+# RUN /opt/common-scripts/env-create  tess /opt/environments/tess/tess.yml
 RUN /opt/common-scripts/install-common tess
 RUN /opt/common-scripts/env-update  tess /opt/environments/tess/tess.pip
 
@@ -21,9 +22,6 @@ RUN /opt/common-scripts/env-update  tess /opt/environments/tess/tess.pip
 USER $NB_UID
 
 RUN /opt/common-scripts/kernel-setup
-
-# Drop kernels not explicitly defined by us,  those preceded with conda-
-RUN jupyter kernelspec list | grep conda\- | awk '{print $1;}' | xargs jupyter kernelspec remove -f
 
 # ---------------------------------------------------------------
 # VARTOOLS Light Curve Analysis Program
@@ -46,7 +44,6 @@ RUN chmod 777 /opt/tessworkshop_tutorials
 RUN mkdir /opt/notebooks
 RUN chmod 777 /opt/notebooks
 
-
 USER $NB_UID
 RUN git clone https://github.com/spacetelescope/tessworkshop_tutorials.git /opt/tessworkshop_tutorials
 RUN git clone https://github.com/spacetelescope/notebooks.git /opt/notebooks
@@ -54,28 +51,45 @@ RUN git clone https://github.com/spacetelescope/notebooks.git /opt/notebooks
 # ========================= ^^^^^ Custom  ^^^^^ =========================
 # ========================= vvvvv Generic vvvvv  =========================
 
-USER root
+# ----------------------------------------------------------------------
+USER $NB_UID
+RUN /opt/common-scripts/kernel-setup   # set up Ipython / JupyterLab kernels
 
-COPY test /opt/test
+# As part of Dockerfile.trailer,  these statements are executed from the
+# perspective of the deployment image directory,  not common.
+
+USER root
 
 # ----------------------------------------------------------------------
 
-RUN cat /opt/common-scripts/global_bashrc >> /etc/bash.bashrc
+# remove this step once nbgitpuller enabled; these contents will be in the
+#  jupyterhub-user-content repo.   Install deployment-specific $HOME files.
+COPY default-home-contents/  /etc/default-home-contents
+RUN  cp -r /home/jovyan/.local  /etc/default-home-contents && \
+     cp -r /home/jovyan/.jupyter /etc/default-home-contents
+COPY global_bashrc  /home/jovyan
+RUN  cat /home/jovyan/global_bashrc   >> /etc/bash.bashrc  && \
+     rm /home/jovyan/global_bashrc
 
-# RUN chown -R ${NB_UID}.${NB_UID} /opt/environments
-RUN  fix-permissions  /opt/environments
+# Fix certs in conda for application level SSL, e.g. pass image-test running on CI-node
+RUN /opt/common-scripts/fix-certs
+
+# For standalone operation outside JupyterHub,  note that  /etc also includes
+# common home directory files.
+RUN cp -r /etc/default-home-contents/* /home/jovyan && \
+    fix-permissions  /home/jovyan  &&\
+    fix-permissions  /opt/environments
+
+# This top level command runs unit tests for the image,  nominally import tests
+# and notebook runs but it's an arbitrary bash script.
+COPY environments/test    /opt/environments/test
+
+# Install security patches now that build is complete;  potentially this could be done sooner
+RUN apt-get update && \
+    apt-get dist-upgrade --yes && \
+    apt-get clean
 
 USER $NB_USER
 WORKDIR /home/$NB_USER
-
-# remove this step once nbgitpuller enabled; these contents will be in the jupyterhub-user-content repo
-COPY default-home-contents/ /etc/default-home-contents/
-
-COPY default-home-contents/ /home/jovyan
-
-# FROM scratch
-# COPY --from=build /  /
-
-
 
 CMD [ "start-notebook.sh" ]

--- a/deployments/tess/image/Dockerfile.custom
+++ b/deployments/tess/image/Dockerfile.custom
@@ -23,9 +23,6 @@ USER $NB_UID
 
 RUN /opt/common-scripts/kernel-setup
 
-# Drop kernels not explicitly defined by us,  those preceded with conda-
-# RUN jupyter kernelspec list | grep conda\- | awk '{print $1;}' | xargs jupyter kernelspec remove -f
-
 # ---------------------------------------------------------------
 # VARTOOLS Light Curve Analysis Program
 USER root
@@ -46,7 +43,6 @@ RUN chmod 777 /opt/tessworkshop_tutorials
 
 RUN mkdir /opt/notebooks
 RUN chmod 777 /opt/notebooks
-
 
 USER $NB_UID
 RUN git clone https://github.com/spacetelescope/tessworkshop_tutorials.git /opt/tessworkshop_tutorials

--- a/deployments/tess/image/environments/tess/tess-frozen.yml
+++ b/deployments/tess/image/environments/tess/tess-frozen.yml
@@ -1,314 +1,404 @@
 name: tess
 channels:
-  - https://ssb.stsci.edu/astroconda
+  - manics
   - conda-forge
-  - defaults
 dependencies:
   - _libgcc_mutex=0.1
   - _openmp_mutex=4.5
-  - arviz=0.10.0
-  - astropy=4.1
-  - astroquery=0.4.1
-  - autograd=1.3
+  - alembic=1.4.3
+  - argon2-cffi=20.1.0
+  - async_generator=1.10
+  - attrs=20.3.0
+  - backcall=0.2.0
+  - backports=1.0
+  - backports.functools_lru_cache=1.6.1
   - beautifulsoup4=4.9.3
-  - binutils_impl_linux-64=2.35.1
-  - binutils_linux-64=2.35
+  - blas=2.14
+  - bleach=3.2.1
+  - blinker=1.4
+  - blosc=1.20.1
   - bokeh=2.2.3
-  - boto3=1.16.20
-  - botocore=1.19.20
+  - bottleneck=1.3.2
+  - brotli=1.0.9
   - brotlipy=0.7.0
+  - brunsli=0.1
   - bzip2=1.0.8
-  - c-ares=1.16.1
-  - ca-certificates=2020.11.8
+  - c-ares=1.17.1
+  - ca-certificates=2020.12.5
   - cached-property=1.5.1
-  - celerite=0.4.0
-  - certifi=2020.11.8
-  - cffi=1.14.3
-  - cftime=1.3.0
+  - certifi=2020.12.5
+  - certipy=0.1.3
+  - cffi=1.14.4
+  - cfitsio=3.470
   - chardet=3.0.4
-  - cryptography=3.2.1
-  - curl=7.71.1
+  - charls=2.1.0
+  - cloudpickle=1.6.0
+  - conda-package-handling=1.7.2
+  - configurable-http-proxy=1.3.0
+  - cryptography=3.3.1
   - cycler=0.10.0
   - cython=0.29.21
-  - dbus=1.13.6
-  - ds9=8.1
-  - expat=2.2.9
-  - fastprogress=1.0.0
-  - fbpca=1.0
-  - fftw=3.3.8
-  - freetds=1.1.15
+  - cytoolz=0.11.0
+  - dask=2.30.0
+  - dask-core=2.30.0
+  - decorator=4.4.2
+  - defusedxml=0.6.0
+  - dill=0.3.3
+  - distributed=2.30.1
+  - entrypoints=0.3
+  - filelock=3.0.12
   - freetype=2.10.4
-  - future=0.18.2
-  - gcc_impl_linux-64=9.3.0
-  - gcc_linux-64=9.3.0
-  - george=0.3.1
-  - gettext=0.19.8.1
-  - ginga=3.1.0
-  - glib=2.66.2
-  - gxx_impl_linux-64=9.3.0
-  - gxx_linux-64=9.3.0
-  - h5py=3.1.0
-  - hdf4=4.2.13
+  - fsspec=0.8.4
+  - giflib=5.2.1
+  - glob2=0.7
+  - gmp=6.2.1
+  - gmpy2=2.1.0b1
   - hdf5=1.10.6
-  - html5lib=1.1
+  - heapdict=1.0.1
+  - icu=67.1
   - idna=2.10
-  - importlib-metadata=2.0.0
-  - importlib_metadata=2.0.0
-  - jeepney=0.5.0
+  - imagecodecs=2020.5.30
+  - imageio=2.9.0
+  - importlib-metadata=3.1.1
+  - importlib_metadata=3.1.1
+  - ipyevents=0.8.1
+  - ipykernel=5.3.4
+  - ipympl=0.5.8
+  - ipython=7.19.0
+  - ipython_genutils=0.2.0
+  - ipywidgets=7.5.1
+  - jedi=0.17.2
   - jinja2=2.11.2
-  - jmespath=0.10.0
+  - joblib=0.17.0
   - jpeg=9d
-  - kernel-headers_linux-64=2.6.32
-  - keyring=21.5.0
+  - json5=0.9.5
+  - jsonschema=3.2.0
+  - jupyter_client=6.1.7
+  - jupyter_core=4.7.0
+  - jupyter_telemetry=0.1.0
+  - jupyterhub=1.2.2
+  - jupyterhub-base=1.2.2
+  - jupyterlab=2.2.9
+  - jupyterlab_pygments=0.1.2
+  - jupyterlab_server=1.2.0
+  - jxrlib=1.1
   - kiwisolver=1.3.1
   - krb5=1.17.2
   - lcms2=2.11
   - ld_impl_linux-64=2.35.1
-  - libblas=3.9.0
-  - libcblas=3.9.0
+  - lerc=2.2
+  - libaec=1.0.4
+  - libarchive=3.5.0
+  - libblas=3.8.0
+  - libcblas=3.8.0
   - libcurl=7.71.1
   - libedit=3.1.20191231
   - libev=4.33
-  - libffi=3.2.1
-  - libgcc-devel_linux-64=9.3.0
+  - libffi=3.3
   - libgcc-ng=9.3.0
-  - libgfortran-ng=9.3.0
-  - libgfortran5=9.3.0
-  - libglib=2.66.2
+  - libgfortran-ng=7.5.0
+  - libgfortran4=7.5.0
   - libgomp=9.3.0
-  - libgpuarray=0.7.6
   - libiconv=1.16
-  - liblapack=3.9.0
-  - libnetcdf=4.7.4
+  - liblapack=3.8.0
+  - liblapacke=3.8.0
+  - liblief=0.10.1
+  - libllvm10=10.0.1
   - libnghttp2=1.41.0
-  - libopenblas=0.3.12
+  - libopenblas=0.3.7
   - libpng=1.6.37
+  - libprotobuf=3.13.0.1
+  - libsodium=1.0.18
   - libssh2=1.9.0
-  - libstdcxx-devel_linux-64=9.3.0
   - libstdcxx-ng=9.3.0
   - libtiff=4.1.0
+  - libuv=1.40.0
   - libwebp-base=1.1.0
-  - lightkurve=1.11.3
-  - llvm-openmp=11.0.0
+  - libxml2=2.9.10
+  - libzopfli=1.0.3
+  - llvmlite=0.34.0
+  - locket=0.2.0
   - lz4-c=1.9.2
+  - lzo=2.10
   - mako=1.1.3
   - markupsafe=1.1.1
   - matplotlib-base=3.3.3
-  - mkl=2020.4
-  - mkl-service=2.3.0
-  - mkl_fft=1.2.0
-  - mpi=1.0
-  - mpi4py=3.0.3
+  - mistune=0.8.4
+  - mock=4.0.2
+  - mpc=1.1.0
+  - mpfr=4.0.2
+  - mpmath=1.1.0
+  - msgpack-python=1.0.0
+  - nbclient=0.5.1
+  - nbconvert=6.0.7
+  - nbformat=5.0.8
   - ncurses=6.2
-  - netcdf4=1.5.4
-  - oktopus=0.1.2
+  - nest-asyncio=1.4.3
+  - networkx=2.5
+  - nodejs=12.19.0
+  - notebook=6.1.5
+  - numba=0.51.2
+  - numexpr=2.7.1
+  - oauthlib=3.0.1
   - olefile=0.46
-  - openmpi=4.0.5
+  - openjpeg=2.3.1
   - openssl=1.1.1h
-  - packaging=20.4
+  - packaging=20.7
+  - pamela=1.0.0
   - pandas=1.1.4
+  - pandoc=2.11.2
+  - pandocfilters=1.4.2
+  - parso=0.7.1
+  - partd=1.1.0
+  - patchelf=0.11
   - patsy=0.5.1
-  - pcre=8.44
+  - pexpect=4.8.0
+  - pickleshare=0.7.5
   - pillow=8.0.1
-  - pip=20.2.4
-  - plotly=4.12.0
-  - pybind11=2.6.1
+  - pip=20.3.1
+  - pkginfo=1.6.1
+  - prometheus_client=0.9.0
+  - prompt-toolkit=3.0.8
+  - protobuf=3.13.0.1
+  - psutil=5.7.3
+  - ptyprocess=0.6.0
+  - py-lief=0.10.1
+  - pycosat=0.6.3
   - pycparser=2.20
-  - pyds9=1.9.0.dev185+gf1f0aae
-  - pyfftw=0.12.0
-  - pygpu=0.7.6
-  - pymc3=3.9.3
-  - pyopenssl=19.1.0
+  - pycurl=7.43.0.6
+  - pygments=2.7.3
+  - pyjwt=1.7.1
+  - pyopenssl=20.0.0
   - pyparsing=2.4.7
+  - pyrsistent=0.17.3
   - pysocks=1.7.1
-  - python=3.7.8
+  - pytables=3.6.1
+  - python=3.8.6
   - python-dateutil=2.8.1
-  - python_abi=3.7
+  - python-editor=1.0.4
+  - python-json-logger=2.0.1
+  - python-libarchive-c=2.9
+  - python_abi=3.8
   - pytz=2020.4
+  - pywavelets=1.1.1
   - pyyaml=5.3.1
-  - qtpy=1.9.0
+  - pyzmq=20.0.0
   - readline=8.0
   - requests=2.25.0
-  - retrying=1.3.3
-  - s3transfer=0.3.3
-  - schwimmbad=0.3.1
+  - ripgrep=12.1.1
+  - ruamel.yaml=0.16.12
+  - ruamel.yaml.clib=0.2.2
+  - ruamel_yaml=0.15.80
+  - scikit-image=0.17.2
+  - scikit-learn=0.23.2
   - scipy=1.5.3
-  - secretstorage=3.2.0
+  - seaborn=0.11.0
+  - seaborn-base=0.11.0
+  - send2trash=1.5.0
   - setuptools=49.6.0
   - six=1.15.0
+  - snappy=1.1.8
+  - sortedcontainers=2.3.0
   - soupsieve=2.0.1
-  - sqlite=3.33.0
-  - starry=0.3.0
-  - sysroot_linux-64=2.12
+  - sqlalchemy=1.3.20
+  - sqlite=3.34.0
+  - statsmodels=0.12.1
+  - sympy=1.7
+  - tblib=1.6.0
+  - terminado=0.9.1
+  - testpath=0.4.4
+  - threadpoolctl=2.1.0
+  - tifffile=2020.12.8
+  - tini=0.18.0
   - tk=8.6.10
+  - toolz=0.11.1
   - tornado=6.1
-  - tqdm=4.52.0
-  - typing-extensions=3.7.4.3
+  - tqdm=4.54.1
+  - traitlets=5.0.5
   - typing_extensions=3.7.4.3
-  - uncertainties=3.1.4
-  - unixodbc=2.3.9
   - urllib3=1.25.11
+  - vincent=0.4.4
+  - wcwidth=0.2.5
   - webencodings=0.5.1
-  - wheel=0.35.1
-  - xarray=0.16.1
+  - websockify=0.9.0
+  - wheel=0.36.1
+  - widgetsnbextension=3.5.1
+  - xlrd=1.2.0
   - xz=5.2.5
   - yaml=0.2.5
+  - zeromq=4.3.3
+  - zfp=0.5.5
+  - zict=2.0.0
   - zipp=3.4.0
   - zlib=1.2.11
   - zstd=1.4.5
   - pip:
     - absl-py==0.11.0
+    - aiohttp==3.7.3
     - alabaster==0.7.12
     - allesfitter==1.1.5
     - ansiwrap==0.8.4
     - appdirs==1.4.4
-    - argon2-cffi==20.1.0
+    - arviz==0.10.0
     - asteval==0.9.21
-    - astor==0.8.1
     - astrobase==0.5.2
     - astrocut==0.7
     - astroml==0.4.1
     - astroml-addons==0.2.2
+    - astropy==4.2
     - astropy-healpix==0.5
-    - async-generator==1.10
-    - attrs==20.3.0
-    - awscli==1.18.180
+    - astropy-sphinx-theme==1.1
+    - astroquery==0.4.1
+    - astunparse==1.6.3
+    - async-timeout==3.0.1
+    - autograd==1.3
+    - awscli==1.18.194
     - babel==2.9.0
-    - backcall==0.2.0
     - batman-package==2.4.7
     - black==20.8b1
-    - bleach==3.2.1
     - blessings==1.7
     - bls-py==0.1.2
+    - boto3==1.16.34
+    - botocore==1.19.34
     - bs4==0.0.1
+    - cachetools==4.2.0
+    - celerite==0.4.0
+    - cftime==1.3.0
+    - ci-watson==0.5
     - click==6.7
+    - codecov==2.1.10
     - colorama==0.4.3
     - corner==2.1.0
+    - coverage==5.3
     - czech-holidays==0.1.3
-    - dask==2.30.0
-    - dataclasses==0.6
-    - decorator==4.4.2
-    - defusedxml==0.6.0
-    - dill==0.3.3
     - docutils==0.15.2
     - dynesty==1.0.1
-    - eleanor==2.0.0
+    - eleanor==0.2.7
     - ellc==1.8.5
     - emcee==3.0.2
-    - entrypoints==0.3
     - everest-pipeline==2.0.12
-    - exoplanet==0.4.2
+    - exoplanet==0.4.3
+    - fastprogress==1.0.0
+    - fbpca==1.0
+    - fitsio==1.1.3
+    - flake8==3.8.4
     - flatbuffers==1.12
-    - gast==0.2.2
+    - future==0.18.2
+    - gast==0.3.3
+    - george==0.3.1
+    - google-auth==1.23.0
+    - google-auth-oauthlib==0.4.2
     - google-pasta==0.2.0
-    - grpcio==1.33.2
-    - imageio==2.9.0
+    - grpcio==1.34.0
+    - h5py==2.10.0
+    - html5lib==1.1
     - imagesize==1.2.0
-    - ipyfilechooser==0.4.0
-    - ipykernel==5.3.4
-    - ipympl==0.5.8
-    - ipython==7.19.0
-    - ipython-genutils==0.2.0
-    - ipywidgets==7.5.1
-    - jax==0.2.5
+    - iniconfig==1.1.1
+    - ipyfilechooser==0.4.1
+    - jax==0.2.7
     - jaxlib==0.1.57
-    - jedi==0.17.2
-    - joblib==0.17.0
+    - jeepney==0.6.0
+    - jmespath==0.10.0
     - jplephem==2.15
-    - jsonschema==3.2.0
     - juliet==2.0.25
-    - jupyter-client==6.1.7
-    - jupyter-core==4.7.0
-    - jupyterlab-pygments==0.1.2
+    - jupyter-desktop-server==0.1.2
+    - jupyter-server-proxy==1.5.0
     - k2flix==2.4.0
     - k2plr==0.2.9
     - keras==2.4.3
-    - keras-applications==1.0.8
     - keras-preprocessing==1.1.2
-    - llvmlite==0.34.0
+    - keyring==21.5.0
+    - lightkurve==1.11.3
     - lmfit==1.0.1
-    - lxml==4.6.1
+    - lxml==4.6.2
     - markdown==3.3.3
+    - mccabe==0.6.1
     - mimeparse==0.1.3
-    - mistune==0.8.4
+    - mplcursors==0.4
+    - muchbettermoments==1.0.0
+    - multidict==5.1.0
     - mypy-extensions==0.4.3
-    - nbclient==0.5.1
-    - nbconvert==6.0.7
-    - nbformat==5.0.8
+    - nbgitpuller==0.9.0
     - nbsphinx==0.8.0
-    - nest-asyncio==1.4.3
-    - notebook==6.1.5
-    - numba==0.51.2
+    - netcdf4==1.5.5
     - numpy==1.18.5
+    - numpydoc==1.1.0
+    - oktopus==0.1.2
     - opt-einsum==3.3.0
-    - pandocfilters==1.4.3
-    - panel==0.10.1
+    - panel==0.10.2
     - papermill==2.2.2
     - param==1.10.0
-    - parso==0.7.1
     - pathspec==0.8.1
-    - pexpect==4.8.0
     - photutils==1.0.1
-    - pickleshare==0.7.5
-    - prometheus-client==0.9.0
-    - prompt-toolkit==3.0.8
-    - protobuf==3.14.0
-    - ptyprocess==0.6.0
+    - pluggy==0.13.1
+    - py==1.9.0
     - pyasn1==0.4.8
-    - pybind11-global==2.6.1
+    - pyasn1-modules==0.2.8
+    - pybind11==2.6.1
+    - pycodestyle==2.6.0
     - pyct==0.4.8
     - pyeebls==0.1.6
-    - pygments==2.7.2
+    - pyerfa==1.7.1.1
+    - pyflakes==2.2.0
+    - pymc3==3.10.0
     - pymc3-ext==0.0.2
     - pypdf2==1.26.0
     - pyriod==0.0.10
-    - pyrsistent==0.17.3
     - pysyzygy==0.0.2
+    - pytest==6.1.2
+    - pytest-cov==2.10.1
+    - pytest-doctestplus==0.8.0
+    - pytest-openfiles==0.5.0
     - python-slugify==4.0.1
     - pyviz-comms==0.7.6
     - pyvo==1.1
     - pyvodb==1.0
-    - pyzmq==20.0.0
     - qgrid==1.3.1
-    - radvel==1.4.2
+    - radvel==1.4.3
     - regex==2020.11.13
     - reproject==0.7.1
+    - requests-mock==1.8.0
+    - requests-oauthlib==1.3.0
     - rsa==4.5
-    - scikit-learn==0.23.2
-    - seaborn==0.11.0
-    - send2trash==1.5.0
+    - s3transfer==0.3.3
+    - secretstorage==3.3.0
     - setuptools-scm==4.1.2
+    - simpervisor==0.3
     - snowballstemmer==2.0.0
     - sphinx==3.3.1
+    - sphinx-asdf==0.1.0rc8
+    - sphinx-astropy==1.3
+    - sphinx-automodapi==0.13
+    - sphinx-bootstrap-theme==0.7.1
+    - sphinx-gallery==0.8.1
+    - sphinx-rtd-theme==0.5.0
     - sphinxcontrib-applehelp==1.0.2
     - sphinxcontrib-devhelp==1.0.2
     - sphinxcontrib-htmlhelp==1.0.3
     - sphinxcontrib-jsmath==1.0.1
     - sphinxcontrib-qthelp==1.0.3
     - sphinxcontrib-serializinghtml==1.1.4
-    - sqlalchemy==1.3.20
+    - stsci-rtd-theme==0.0.2
     - tele-scope==1.0.5
     - tenacity==6.2.0
-    - tensorboard==1.15.0
-    - tensorflow==1.15.4
-    - tensorflow-estimator==1.15.1
+    - tensorboard==2.4.0
+    - tensorboard-plugin-wit==1.7.0
+    - tensorflow==2.3.1
+    - tensorflow-estimator==2.3.0
     - termcolor==1.1.0
-    - terminado==0.9.1
-    - tess-point==0.5.1
-    - testpath==0.4.4
+    - tess-point==0.6.0
     - text-unidecode==1.3
     - textwrap3==0.9.2
-    - theano==1.0.5
-    - threadpoolctl==2.1.0
+    - theano-pymc==1.0.11
     - toml==0.10.2
-    - torch==1.7.0
-    - traitlets==5.0.5
+    - torch==1.7.1
     - tvguide==1.0.3
     - typed-ast==1.4.1
+    - uncertainties==3.1.5
     - vaneska==0.0.dev0
-    - wcwidth==0.2.5
     - werkzeug==1.0.1
-    - widgetsnbextension==3.5.1
     - wotan==1.9
     - wrapt==1.12.1
+    - xarray==0.16.2
+    - yarl==1.6.3
 prefix: /opt/conda/envs/tess

--- a/deployments/tess/image/environments/tess/tess.yml
+++ b/deployments/tess/image/environments/tess/tess.yml
@@ -30,6 +30,5 @@ dependencies:
 
 # - jwst-visit-parser
 # - jwst_gtvt
-# - cfitsio
 # - fitsverify
 # - stsci

--- a/deployments/tess/image/global_bashrc
+++ b/deployments/tess/image/global_bashrc
@@ -1,0 +1,6 @@
+export PS1="${debian_chroot:+($debian_chroot)}\u@notebook:\w\$ "
+
+# Enable conda and activate jwst-masterclass by default
+. /opt/conda/etc/profile.d/conda.sh
+
+conda activate tess

--- a/tools/docker-history
+++ b/tools/docker-history
@@ -1,0 +1,5 @@
+#! /bin/bash -eu
+
+# Print Docker history of the most recently built image.
+# If you want some other image,  just use "docker history"
+docker history --no-trunc `docker image ls |  head -2 | tail -1 | awk '{ print $3; }'`

--- a/tools/image-build
+++ b/tools/image-build
@@ -1,4 +1,4 @@
-#! /bin/bash -eux
+#! /bin/bash -eu
 
 # Build the combined deployment image,  including:
 # 1. Perform any required source code updates,  including updating SSL certs

--- a/tools/image-scan
+++ b/tools/image-scan
@@ -4,4 +4,4 @@ cd  $JUPYTERHUB_DIR
 image-scan-report "$IMAGE_UBUNTU_NAME" $IMAGE_VULNERABILITY_LEVEL >ecr-scan-report.yaml
 
 echo "============================== ECR Scan Summary ================================"
-image-scan-summary report.yaml
+image-scan-summary ecr-scan-report.yaml

--- a/tools/image-scan-report
+++ b/tools/image-scan-report
@@ -23,6 +23,7 @@ import copy
 
 import requests
 import bs4
+import time
 
 admin_arn=os.environ["ADMIN_ARN"]
 image_repo=os.environ["IMAGE_REPO"]

--- a/tools/image-sh
+++ b/tools/image-sh
@@ -3,4 +3,4 @@
 # Run a bash shell in the last tagged mission container.  This will lag
 # behind any partially built container with newer image layers.
 
-image-exec /bin/bash
+image-exec /bin/bash --rcfile /etc/bash.bashrc


### PR DESCRIPTION
 Revert "Merge pull request #37 from spacetelescope/kernel-setup-cleanup" This reverts commit 
   e4b0e158e1c9b1a30cbd374fbecb9e8687de486b, reversing
   changes made to 93e0abe8a1b8834c5c3d042fbf20179bd5ba07d0.
   Kernel cleanup broke image-test scripted standalone testing.
Updated scipy notebook base image to get better support for kernel name configuration.
Added custom global_bashrc to roman and tess deployments to configure default kernel and shell prompt,  installed as /etc/bash.bashrc.
Added roman-cal kernel to the JWST example notebook by direct editing.
Dropped nb_notebook_kernels and nb_conda,  code in kernel-setup to remove automatic kernels/names
Added cfitsio and supporting libraries to common base image and conda environment for TESS.
Updated image-sh to load /etc/bash.bashrc at shell startup to get default environment.
Bugfix name of report in image-scan summary step
Bugfix missing time import,  image-scan-report
Remove -x from image-build script.
Added docker-history script to help debug image memory consumption,  costly layers.
Added apt-get dist-upgrade to common Dockerfile.trailer to update ubunutu packages
Updated scipy-notebook hash and frozen image package versions for TESS and Roman.