### PR TITLE
Tess dev hub setup

### DIFF
--- a/deployments/roman/config/common.yaml
+++ b/deployments/roman/config/common.yaml
@@ -35,9 +35,3 @@ jupyterhub:
     memory:
       guarantee: 8G
       limit: 15G
-  auth:
-    users:
-      - add-me@stsci.edu
-    admin:
-      users:
-         - add-me@stsci.edu

--- a/deployments/tess/config/common.yaml
+++ b/deployments/tess/config/common.yaml
@@ -17,7 +17,7 @@ jupyterhub:
       enabled: true
   singleuser:
     image:
-      tag: mission-latest
+      tag: tess-latest
       pullPolicy: Always
     lifecycleHooks:
       postStart:
@@ -29,11 +29,6 @@ jupyterhub:
         CRDS_SERVER_URL: https://jwst-crds.stsci.edu
     defaultUrl: "/lab"
     memory:
-      guarantee: 512M
-      limit: 1G
-  auth:
-    users:
-      - add-me@stsci.edu
-    admin:
-      users:
-      - add-me@stsci.edu
+      guarantee: 4G
+      limit: 10G
+

--- a/deployments/tess/config/common.yaml
+++ b/deployments/tess/config/common.yaml
@@ -17,7 +17,7 @@ jupyterhub:
       enabled: true
   singleuser:
     image:
-      tag: tess-latest
+      tag: latest
       pullPolicy: Always
     storage:
       dynamic:

--- a/deployments/tess/config/common.yaml
+++ b/deployments/tess/config/common.yaml
@@ -19,6 +19,9 @@ jupyterhub:
     image:
       tag: tess-latest
       pullPolicy: Always
+    storage:
+      dynamic:
+        storageClass: "aws-efs"
     lifecycleHooks:
       postStart:
         exec:

--- a/derived-env
+++ b/derived-env
@@ -25,3 +25,10 @@ export IMAGE_DIR=`pwd`/deployments/${DEPLOYMENT_NAME}/image
 export IMAGE_ID=${ACCOUNT}/${IMAGE_REPO}:${IMAGE_TAG}
 
 export PATH="`pwd`/tools":${PATH}
+
+# --------------- general setup ---------------------------------
+
+export TMOUT=7200
+export TF_LOG=TRACE
+export TF_LOG_PATH=terraform.log
+

--- a/doc/example-secrets-env-decrypted.yaml
+++ b/doc/example-secrets-env-decrypted.yaml
@@ -16,6 +16,11 @@ jupyterhub:
                     [REDACTED]
                     -----END CERTIFICATE-----
     auth:
+        users:
+        - add-me@stsci.edu
+        admin:
+            users:
+            - add-me@stsci.edu
         type: custom
         custom:
             className: oauthenticator.generic.GenericOAuthenticator

--- a/setup-env.template
+++ b/setup-env.template
@@ -9,7 +9,7 @@
 export ACCOUNT_ID=12345678
 export ADMIN_ROLENAME=admin-role
 export DEPLOYMENT_NAME=cluster-name
-export IMAGE_TAG=mission-latest
+export IMAGE_TAG=latest
 export COMMON_TAG=common-latest
 
 # sandbox, dev, test, or prod

--- a/tools/secrets-edit
+++ b/tools/secrets-edit
@@ -6,7 +6,7 @@
 
 secrets_file=${ENVIRONMENT}.yaml
 
-cd ${JUPYTERHUB_DIR}/secrets/deployments/${DEPLOYMENT_NAME}/secrets
+cd ${JUPYTERHUB_DIR}/deployments/${DEPLOYMENT_NAME}/secrets
 
 awsudo $ADMIN_ARN sops $secrets_file
 

--- a/tools/secrets-push
+++ b/tools/secrets-push
@@ -2,6 +2,7 @@
 
 # Push the secrets repo back up to the codecommit repository
 
-cd ${JUPYTERHUB_DIR}/secrets/deployments/${DEPLOYMENT_NAME}/secrets
+cd ${JUPYTERHUB_DIR}/deployments/${DEPLOYMENT_NAME}/secrets
 
-awsudo arn:aws:iam::${ACCOUNT_ID}:role/${DEPLOYMENT_NAME}-secrets-repo-setup git push
+awsudo $ADMIN_ARN git push
+


### PR DESCRIPTION
Fixes secrets scripts broken by move of secrets directory.
Moves e-mails from config/common.yaml to the secrets template.
Sets TESS memory allocations to 4G guaranteed, 10G limit basically assuming t3.xlarge.
Adds new EFS configuration to TESS common.yaml,  roman still needs it.
Adds ssh session timeout and Terraform logging env variables to setup-env.template.
Update TESS EFS configuration in common.yaml to avoid creation of EBS,  node affinity conflicts
Switched image tag from <mission>-latest back to latest in TESS, Roman, setup-env.template.