### PR TITLE
Setup notebooks updates

### DIFF
--- a/deployments/common/image/common-scripts/set-notebook-kernel
+++ b/deployments/common/image/common-scripts/set-notebook-kernel
@@ -16,9 +16,9 @@ def set_kernel(kernel, display_name, notebook):
     with open(notebook) as nbf:
         loaded = json.loads(nbf.read())
         spec = loaded["metadata"]["kernelspec"]
-        spec["display_name"] = kernel
+        spec["display_name"] = display_name
         spec["language"] = "python"
-        spec["name"] = display_name
+        spec["name"] = kernel
     with open(notebook, "w+") as nbf:
         nbf.write(json.dumps(loaded, indent=1))
 

--- a/deployments/jwebbinar/image/environments/jdaviz/tests/notebooks
+++ b/deployments/jwebbinar/image/environments/jdaviz/tests/notebooks
@@ -1,2 +1,1 @@
 /home/jovyan/jwebbinar_prep/test_environment/JWebbinar_viztool_tests.ipynb
-/home/jovyan/jwebbinar_prep/test_environment/pipeline_testenv_nirissdata.ipynb

--- a/deployments/jwebbinar/image/environments/jwebbinar/tests/notebooks
+++ b/deployments/jwebbinar/image/environments/jwebbinar/tests/notebooks
@@ -1,0 +1,1 @@
+/home/jovyan/jwebbinar_prep/test_environment/pipeline_testenv_nirissdata.ipynb

--- a/deployments/jwebbinar/image/environments/setup-notebooks
+++ b/deployments/jwebbinar/image/environments/setup-notebooks
@@ -7,4 +7,10 @@
 
 gitpuller https://github.com/spacetelescope/jwebbinar_prep test-env jwebbinar_prep
 
-/opt/common-scripts/set-notebook-kernel jdaviz jdaviz jwebbinar_prep/test_environment/*.ipynb
+/opt/common-scripts/set-notebook-kernel jdaviz jdaviz jwebbinar_prep/test_environment/JWebbinar_viztool_tests.ipynb
+
+/opt/common-scripts/set-notebook-kernel jwebbinar JWebbinar jwebbinar_prep/test_environment/pipeline_testenv_nirissdata.ipynb
+
+# /opt/common-scripts/set-notebook-kernel jwebbinar JWebbinar jwebbinar_prep/pipeline_products_session/*.ipynb
+
+# /opt/common-scripts/set-notebook-kernel jwebbinar JWebbinar jwebbinar_prep/imaging_mode/*.ipynb


### PR DESCRIPTION
Bugfix set-notebook-kernel, display name and kernel name backwards.
Updated setup-notebooks in a basic manner, switching existing pipeline
     notebook to jwebbinar kernel, adding possible changes for coming
     jwebbinar_prep PR's as comments.
Modified jdaviz and jwebbinar tests/notebooks to move pipeline notebook
    to jwebbinar for testing.
