### PR TITLE
Tweaks to fix tike and roman builds and testing

### DIFF
--- a/deployments/common/image/Dockerfile.trailer
+++ b/deployments/common/image/Dockerfile.trailer
@@ -25,7 +25,7 @@ RUN /opt/common-scripts/fix-certs
 
 # This top level command runs unit tests for the image,  nominally import tests
 # and notebook runs but it's an arbitrary bash script.
-COPY environments/test    /opt/environments/test
+COPY --chown=${NB_UID}:${NB_GID} environments/test    /opt/environments/test
 
 # Install security patches now that build is complete;  potentially this could be done sooner
 RUN apt-get update && \

--- a/deployments/roman/image/Dockerfile
+++ b/deployments/roman/image/Dockerfile
@@ -28,10 +28,10 @@ ENV CRDS_VERBOSITY=20
 USER ${NB_UID}
 
 # All specs for frozen builds need to be available before their normal installs
-COPY environments/frozen/  /opt/environments/frozen
+COPY --chown=${NB_UID}:${NB_GID} environments/frozen/  /opt/environments/frozen
 
 # Roman CAL
-COPY environments/roman-cal/ /opt/environments/roman-cal
+COPY --chown=${NB_UID}:${NB_GID} environments/roman-cal/ /opt/environments/roman-cal
 # RUN /opt/common-scripts/env-clone base roman-cal   # too many conflicts
 RUN /opt/common-scripts/env-create  roman-cal /opt/environments/roman-cal/roman-cal.yml
 RUN /opt/common-scripts/install-common roman-cal
@@ -39,14 +39,14 @@ RUN /opt/common-scripts/env-update  roman-cal /opt/environments/roman-cal/roman-
 RUN /opt/common-scripts/env-update  roman-cal /opt/environments/roman-cal/octarine.pip
 
 # MIRAGE
-COPY environments/mirage/ /opt/environments/mirage
+COPY --chown=${NB_UID}:${NB_GID} environments/mirage/ /opt/environments/mirage
 # RUN /opt/common-scripts/env-create  mirage /opt/environments/mirage/mirage.yml
 RUN /opt/common-scripts/env-clone base mirage
 RUN /opt/common-scripts/env-update  mirage /opt/environments/mirage/mirage.pip
 RUN /opt/common-scripts/install-common mirage
 
 # CVT
-COPY environments/cvt/ /opt/environments/cvt
+COPY --chown=${NB_UID}:${NB_GID} environments/cvt/ /opt/environments/cvt
 RUN /opt/common-scripts/env-clone  base   cvt
 # RUN /opt/common-scripts/env-create  cvt /opt/environments/cvt/cvt.yml
 RUN /opt/common-scripts/install-common cvt
@@ -97,7 +97,7 @@ RUN /opt/common-scripts/fix-certs
 
 # This top level command runs unit tests for the image,  nominally import tests
 # and notebook runs but it's an arbitrary bash script.
-COPY environments/test    /opt/environments/test
+COPY --chown=${NB_UID}:${NB_GID} environments/test    /opt/environments/test
 
 # Install security patches now that build is complete;  potentially this could be done sooner
 RUN apt-get update && \

--- a/deployments/roman/image/Dockerfile.custom
+++ b/deployments/roman/image/Dockerfile.custom
@@ -28,10 +28,10 @@ ENV CRDS_VERBOSITY=20
 USER ${NB_UID}
 
 # All specs for frozen builds need to be available before their normal installs
-COPY environments/frozen/  /opt/environments/frozen
+COPY --chown=${NB_UID}:${NB_GID} environments/frozen/  /opt/environments/frozen
 
 # Roman CAL
-COPY environments/roman-cal/ /opt/environments/roman-cal
+COPY --chown=${NB_UID}:${NB_GID} environments/roman-cal/ /opt/environments/roman-cal
 # RUN /opt/common-scripts/env-clone base roman-cal   # too many conflicts
 RUN /opt/common-scripts/env-create  roman-cal /opt/environments/roman-cal/roman-cal.yml
 RUN /opt/common-scripts/install-common roman-cal
@@ -39,14 +39,14 @@ RUN /opt/common-scripts/env-update  roman-cal /opt/environments/roman-cal/roman-
 RUN /opt/common-scripts/env-update  roman-cal /opt/environments/roman-cal/octarine.pip
 
 # MIRAGE
-COPY environments/mirage/ /opt/environments/mirage
+COPY --chown=${NB_UID}:${NB_GID} environments/mirage/ /opt/environments/mirage
 # RUN /opt/common-scripts/env-create  mirage /opt/environments/mirage/mirage.yml
 RUN /opt/common-scripts/env-clone base mirage
 RUN /opt/common-scripts/env-update  mirage /opt/environments/mirage/mirage.pip
 RUN /opt/common-scripts/install-common mirage
 
 # CVT
-COPY environments/cvt/ /opt/environments/cvt
+COPY --chown=${NB_UID}:${NB_GID} environments/cvt/ /opt/environments/cvt
 RUN /opt/common-scripts/env-clone  base   cvt
 # RUN /opt/common-scripts/env-create  cvt /opt/environments/cvt/cvt.yml
 RUN /opt/common-scripts/install-common cvt

--- a/deployments/roman/image/environments/roman-cal/roman-cal.pip
+++ b/deployments/roman/image/environments/roman-cal/roman-cal.pip
@@ -1,2 +1,2 @@
 jwst==0.17.1
-git+https://github.com/spacetelescope/romancal.git
+romancal==0.2.0

--- a/deployments/tike/image/Dockerfile
+++ b/deployments/tike/image/Dockerfile
@@ -12,10 +12,10 @@ ENV USE_FROZEN=$USE_FROZEN
 USER ${NB_UID}
 
 # All specs for frozen builds need to be available before their normal installs
-COPY environments/frozen/  /opt/environments/frozen
+COPY --chown=${NB_UID}:${NB_GID} environments/frozen/  /opt/environments/frozen
 
 # TESS
-COPY environments/tess/ /opt/environments/tess
+COPY --chown=${NB_UID}:${NB_GID}  environments/tess/ /opt/environments/tess
 RUN /opt/common-scripts/env-clone  base  tess
 # RUN /opt/common-scripts/env-create  tess /opt/environments/tess/tess.yml
 RUN /opt/common-scripts/install-common tess
@@ -79,7 +79,7 @@ RUN /opt/common-scripts/fix-certs
 
 # This top level command runs unit tests for the image,  nominally import tests
 # and notebook runs but it's an arbitrary bash script.
-COPY environments/test    /opt/environments/test
+COPY --chown=${NB_UID}:${NB_GID} environments/test    /opt/environments/test
 
 # Install security patches now that build is complete;  potentially this could be done sooner
 RUN apt-get update && \
@@ -89,12 +89,8 @@ RUN apt-get update && \
 # For standalone operation outside JupyterHub,  note that  /etc also includes
 # common home directory files.
 
-RUN tree -a /etc/default-home-contents/
-
 RUN cp -r /etc/default-home-contents/* /home/jovyan && \
     fix-permissions  /home/jovyan
-
-RUN tree -a /home/jovyan
 
 USER $NB_USER
 WORKDIR /home/$NB_USER

--- a/deployments/tike/image/Dockerfile.custom
+++ b/deployments/tike/image/Dockerfile.custom
@@ -12,10 +12,10 @@ ENV USE_FROZEN=$USE_FROZEN
 USER ${NB_UID}
 
 # All specs for frozen builds need to be available before their normal installs
-COPY environments/frozen/  /opt/environments/frozen
+COPY --chown=${NB_UID}:${NB_GID} environments/frozen/  /opt/environments/frozen
 
 # TESS
-COPY environments/tess/ /opt/environments/tess
+COPY --chown=${NB_UID}:${NB_GID}  environments/tess/ /opt/environments/tess
 RUN /opt/common-scripts/env-clone  base  tess
 # RUN /opt/common-scripts/env-create  tess /opt/environments/tess/tess.yml
 RUN /opt/common-scripts/install-common tess

--- a/deployments/tike/image/default-home-contents/.astropy/config/astroquery.cfg
+++ b/deployments/tike/image/default-home-contents/.astropy/config/astroquery.cfg
@@ -1,0 +1,5 @@
+[mast]
+
+# Override MAST server with JWST A-string so we have access to
+# relevant data:
+server = https://pwjwdmsauiweb.stsci.edu


### PR DESCRIPTION
Modify tike and roman Dockerfiles to chown anything copied to /opt to NB_UID:NB_GID.  This mimics scipy-notebook and also enables chdir'ing to test directories in /opt that supply supporting files to test notebooks and also supports writing outputs in the CWD.   This writability used to be accomplished  by a very late fix-permissions but that was dropped because it invalidated the Docker cache for all environments.

Added default-home-contents to tike to make Dockerfile.trailer work,  also sets up astroquery for MAST.  

Switched roman-cal from a git checkout to PyPi romancal-0.2.0.

Testing is "fixed" in the sense that tests don't fail because the framework isn't set up right,  they fail because they fail.

tike and roman frozen builds are obsolete,   their updates didn't build so were not committed.