### PR TITLE
Basic GitHub Actions CI

### DIFF
--- a/.github/workflows/scan-build-test-scan.yml
+++ b/.github/workflows/scan-build-test-scan.yml
@@ -1,0 +1,87 @@
+name: docker
+
+on:
+   schedule:
+     - cron: '0 0 */7 * *'
+   push:
+      branches:
+        - main
+   pull_request:
+      branches:
+        - main
+
+jobs:
+  docker:
+    name: "${{ matrix.DEPLOYMENT_NAME }}  -- scan, build, test, scan"
+    runs-on: ubuntu-18.04
+
+    strategy:
+      max-parallel: 5
+      fail-fast: false
+      matrix:
+        DEPLOYMENT_NAME: [ jwebbinar, roman, tike]
+        USE_FROZEN: [ 0 ]
+
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v2
+
+      - name: free disk space, prepare swap
+        run: |
+             df -h
+             sudo apt clean
+             docker rmi $(docker image ls -aq)
+             docker container prune -f
+             sudo rm -rf "/usr/local/share/boost"
+             sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+             sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
+             sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
+             sudo swapoff -a
+             sudo rm -f /swapfile
+             sudo fallocate -l 20G /swapfile
+             sudo chmod 0600 /swapfile
+             sudo mkswap /swapfile
+             sudo swapon /swapfile
+             cat /proc/meminfo
+             df -h
+
+      - name: set up environment
+        run: |
+           tools/image-configure ${{ matrix.DEPLOYMENT_NAME }}  ${{ matrix.USE_FROZEN }}
+           df -h
+
+      - name: source code scan
+        run: |
+           source setup-env
+           tools/source-scan
+
+      - name: image build
+        run: |
+           source setup-env
+           tools/image-build
+           df -h
+           docker image ls
+
+      - name: git diffs (frozen specs)
+        run: git diff
+
+      # - name: Anchore image scan
+      #   uses: anchore/scan-action@v2
+      #   with:
+      #      image: standalone_jupyterlab/${{ matrix.DEPLOYMENT_NAME }}-user-image:latest
+      #      acs-report-enable: true
+      #      fail-build: false
+      #      severity-cutoff: high
+
+      # - name: grype scan JSON results
+      #   run: for j in `ls ./anchore-reports/*.json`; do echo "---- ${j} ----"; cat ${j}; echo; done
+
+      # - name: Inspect action SARIF report
+      #   run: cat ${{ steps.scan.outputs.sarif }}
+
+      - name: image test
+        run: |
+           df -h
+           source setup-env
+           tools/image-test
+           df -h

--- a/deployments/common/image/Dockerfile.trailer
+++ b/deployments/common/image/Dockerfile.trailer
@@ -30,7 +30,8 @@ COPY --chown=${NB_UID}:${NB_GID} environments/test    /opt/environments/test
 # Install security patches now that build is complete;  potentially this could be done sooner
 RUN apt-get update && \
     apt-get dist-upgrade --yes && \
-    apt-get clean
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # For standalone operation outside JupyterHub,  note that  /etc also includes
 # common home directory files.

--- a/deployments/common/image/common-scripts/env-clone
+++ b/deployments/common/image/common-scripts/env-clone
@@ -15,3 +15,5 @@ fi
 echo "-------------------------------------------------------------------------------"
 echo "Cloning env $to from env $from"
 conda create --name $to  --clone $from
+
+/opt/common-scripts/env-clean

--- a/deployments/common/image/common-scripts/env-create
+++ b/deployments/common/image/common-scripts/env-create
@@ -37,5 +37,4 @@ else
     conda create --name  ${env} python
 fi
 
-conda clean -fya
-conda build purge-all
+/opt/common-scripts/env-clean

--- a/deployments/common/image/common-scripts/test-notebooks
+++ b/deployments/common/image/common-scripts/test-notebooks
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-#-*-python-*-
+# -*-python-*-
 
 """Using the Python env/kernel specified by the first parameter, execute all
 notebooks specified by subsequent parameters.
@@ -8,37 +8,61 @@ notebooks specified by subsequent parameters.
 import sys
 import os.path
 import subprocess
+import glob
+import shutil
+import uuid
 
-if (len(sys.argv) < 2):  # accept 0 notebooks...
-    print("test-notebooks <kernel>  <notebooks...>", file=sys.stderr)
-    sys.exit(1)
 
-kernel = sys.argv[1]
-notebooks = sys.argv[2:]
+def test_notebooks(kernel, notebook_globs):
+    """Run all the notebooks specified by globbing `notebook_globs` using `kernel`.
 
-errs = 0
-for notebook in notebooks:
+    Return   count of failed notebooks
+    """
+    notebooks = [
+        notebook for pattern in notebook_globs for notebook in glob.glob(pattern)
+    ]
+    errs = 0
+    for notebook in notebooks:
+        if notebook.startswith("#"):
+            print("=" * 10, "Skipping Notebook", notebook, "=" * 10)
+            continue
+        print("=" * 10, "Testing Notebook", notebook, "=" * 10)
+        err = test_notebook(kernel, notebook)
+        print("Tested notebook", notebook, "... ok" if not err else "... FAIL")
+        errs += err
+    return errs
 
-    if notebook.startswith("#"):
-        print("="*10, "Skipping Notebook", notebook, "="*10)
-        continue
 
-    print("="*10, "Testing Notebook", notebook, "="*10)
+def test_notebook(kernel, notebook):
+    here = os.getcwd()
+    err = 1  # assume failed
+    try:
+        source_path = os.path.dirname(os.path.abspath(notebook))
 
-    os.chdir(os.path.dirname(notebook))
+        temp_dir = "/tmp/" + str(uuid.uuid4())
+        shutil.copytree(source_path, temp_dir)
+        os.chdir(temp_dir)
 
-    err = subprocess.call(f"papermill {notebook} /tmp/test.ipynb -k {kernel}".split())
-    if err == 0:
-        print("Tested notebook", notebook, "... ok")
-    else:
-        print("Tested notebook", notebook, "... FAIL")
-        errs += 1
+        notebook_copy = f"{temp_dir}/{os.path.basename(notebook)}"
+        err = subprocess.call(
+            f"papermill {notebook_copy} test.ipynb -k {kernel}".split()
+        )  # maybe succeeds
 
-sys.exit(errs)
+        shutil.rmtree(temp_dir, ignore_errors=True)
+    finally:
+        os.chdir(here)
+    return int(err != 0)
 
-#
-# nbconvert version of notebook runner as an alternative to papermill.
-#
-# If needed,  nbconvert also has a switch to specify kernel...
-# err = subprocess.call(f"jupyter nbconvert --to notebook  --NotebookClient.kernel_name={kernel} "
-#                       f"--ExecutePreprocessor.kernel_name={kernel} --execute {notebook}".split())
+
+def main(*args):
+    if len(args) < 2:  # accept 0 notebooks...
+        print("test-notebooks <kernel>  <notebooks...>", file=sys.stderr)
+        sys.exit(2)
+    kernel = sys.argv[1]
+    notebook_globs = sys.argv[2:]
+    return test_notebooks(kernel, notebook_globs)
+
+
+if __name__ == "__main__":
+    if main(*sys.argv):
+        sys.exit(1)

--- a/deployments/jwebbinar/image/Dockerfile
+++ b/deployments/jwebbinar/image/Dockerfile
@@ -29,9 +29,10 @@ USER root
 
 # Get webbpsf-data-0.9.0.tar.gz
 RUN mkdir /data && cd /data && \
-    wget --quiet https://stsci.box.com/shared/static/qcptcokkbx7fgi3c00w2732yezkxzb99.gz
-RUN cd /data && tar zxf qcptcokkbx7fgi3c00w2732yezkxzb99.gz && \
-    rm qcptcokkbx7fgi3c00w2732yezkxzb99.gz && chmod -R a+r /data/webbpsf-data
+    wget --quiet https://stsci.box.com/shared/static/qcptcokkbx7fgi3c00w2732yezkxzb99.gz && \
+    tar zxf qcptcokkbx7fgi3c00w2732yezkxzb99.gz && \
+    rm qcptcokkbx7fgi3c00w2732yezkxzb99.gz && \
+    chmod -R a+r /data/webbpsf-data
 
 # Install sextractor under /usr/local
 RUN cd /tmp && \
@@ -51,7 +52,7 @@ USER ${NB_UID}
 # build will back up to this point.  Consequently, image build uses git to
 # clear the new specs, they should be committed to git prior to attempting a
 # new frozen build.
-COPY environments/frozen /opt/environments/frozen
+COPY --chown=${NB_UID}:${NB_GID} environments/frozen /opt/environments/frozen
 
 # ----------------------------------------------------------------------
 # BUG: ds9 is installed in the jwebbinar kernel, but it's included also include in the
@@ -64,14 +65,14 @@ RUN conda env remove --name ds9
 
 # ----------------------------------------------------------------------
 # JWebbinar
-COPY environments/jwebbinar/ /opt/environments/jwebbinar
+COPY --chown=${NB_UID}:${NB_GID} environments/jwebbinar/ /opt/environments/jwebbinar
 RUN /opt/common-scripts/env-create jwebbinar /opt/environments/jwebbinar/jwebbinar.yml
 RUN /opt/common-scripts/install-common jwebbinar
 RUN /opt/common-scripts/env-update jwebbinar /opt/environments/jwebbinar/jwebbinar.pip
 
 RUN /opt/common-scripts/install-common jwebbinar
 
-COPY environments/jwebbinar/ /opt/environments/jwebbinar
+COPY --chown=${NB_UID}:${NB_GID} environments/jwebbinar/ /opt/environments/jwebbinar
 
 # ----------------------------------------------------------------------
 # Jdaviz
@@ -82,7 +83,7 @@ RUN /opt/common-scripts/env-update jdaviz /opt/environments/jdaviz/jdaviz.pip
 
 RUN /opt/common-scripts/install-common jdaviz
 
-COPY environments/jdaviz/ /opt/environments/jdaviz
+COPY --chown=${NB_UID}:${NB_GID} environments/jdaviz/ /opt/environments/jdaviz
 
 # ----------------------------------------------------------------------
 USER root
@@ -104,7 +105,7 @@ RUN jupyter nbextension install --py --sys-prefix widgetsnbextension && \
     rm -rf "/home/${NB_USER}/.cache/yarn" && \
     rm -rf "/home/${NB_USER}/.node-gyp"
 
-COPY environments/setup-notebooks  /opt/environments
+COPY  --chown=${NB_UID}:${NB_GID} environments/setup-notebooks  /opt/environments
 RUN  /opt/environments/setup-notebooks
 
 # Fix JS encoding issue that prevents widgets from displaying properly in notebook mode
@@ -144,7 +145,8 @@ COPY --chown=${NB_UID}:${NB_GID} environments/test    /opt/environments/test
 # Install security patches now that build is complete;  potentially this could be done sooner
 RUN apt-get update && \
     apt-get dist-upgrade --yes && \
-    apt-get clean
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # For standalone operation outside JupyterHub,  note that  /etc also includes
 # common home directory files.

--- a/deployments/jwebbinar/image/Dockerfile.custom
+++ b/deployments/jwebbinar/image/Dockerfile.custom
@@ -29,9 +29,10 @@ USER root
 
 # Get webbpsf-data-0.9.0.tar.gz
 RUN mkdir /data && cd /data && \
-    wget --quiet https://stsci.box.com/shared/static/qcptcokkbx7fgi3c00w2732yezkxzb99.gz
-RUN cd /data && tar zxf qcptcokkbx7fgi3c00w2732yezkxzb99.gz && \
-    rm qcptcokkbx7fgi3c00w2732yezkxzb99.gz && chmod -R a+r /data/webbpsf-data
+    wget --quiet https://stsci.box.com/shared/static/qcptcokkbx7fgi3c00w2732yezkxzb99.gz && \
+    tar zxf qcptcokkbx7fgi3c00w2732yezkxzb99.gz && \
+    rm qcptcokkbx7fgi3c00w2732yezkxzb99.gz && \
+    chmod -R a+r /data/webbpsf-data
 
 # Install sextractor under /usr/local
 RUN cd /tmp && \
@@ -51,7 +52,7 @@ USER ${NB_UID}
 # build will back up to this point.  Consequently, image build uses git to
 # clear the new specs, they should be committed to git prior to attempting a
 # new frozen build.
-COPY environments/frozen /opt/environments/frozen
+COPY --chown=${NB_UID}:${NB_GID} environments/frozen /opt/environments/frozen
 
 # ----------------------------------------------------------------------
 # BUG: ds9 is installed in the jwebbinar kernel, but it's included also include in the
@@ -64,14 +65,14 @@ RUN conda env remove --name ds9
 
 # ----------------------------------------------------------------------
 # JWebbinar
-COPY environments/jwebbinar/ /opt/environments/jwebbinar
+COPY --chown=${NB_UID}:${NB_GID} environments/jwebbinar/ /opt/environments/jwebbinar
 RUN /opt/common-scripts/env-create jwebbinar /opt/environments/jwebbinar/jwebbinar.yml
 RUN /opt/common-scripts/install-common jwebbinar
 RUN /opt/common-scripts/env-update jwebbinar /opt/environments/jwebbinar/jwebbinar.pip
 
 RUN /opt/common-scripts/install-common jwebbinar
 
-COPY environments/jwebbinar/ /opt/environments/jwebbinar
+COPY --chown=${NB_UID}:${NB_GID} environments/jwebbinar/ /opt/environments/jwebbinar
 
 # ----------------------------------------------------------------------
 # Jdaviz
@@ -82,7 +83,7 @@ RUN /opt/common-scripts/env-update jdaviz /opt/environments/jdaviz/jdaviz.pip
 
 RUN /opt/common-scripts/install-common jdaviz
 
-COPY environments/jdaviz/ /opt/environments/jdaviz
+COPY --chown=${NB_UID}:${NB_GID} environments/jdaviz/ /opt/environments/jdaviz
 
 # ----------------------------------------------------------------------
 USER root
@@ -104,7 +105,7 @@ RUN jupyter nbextension install --py --sys-prefix widgetsnbextension && \
     rm -rf "/home/${NB_USER}/.cache/yarn" && \
     rm -rf "/home/${NB_USER}/.node-gyp"
 
-COPY environments/setup-notebooks  /opt/environments
+COPY  --chown=${NB_UID}:${NB_GID} environments/setup-notebooks  /opt/environments
 RUN  /opt/environments/setup-notebooks
 
 # Fix JS encoding issue that prevents widgets from displaying properly in notebook mode

--- a/deployments/jwebbinar/image/environments/jwebbinar/tests/notebooks
+++ b/deployments/jwebbinar/image/environments/jwebbinar/tests/notebooks
@@ -1,1 +1,1 @@
-/home/jovyan/jwebbinar_prep/test_environment/pipeline_testenv_nirissdata.ipynb
+/home/jovyan/JWebbinar jwebbinar_prep/pipeline_products_session/jwst-data-products-*.ipynb

--- a/deployments/roman/image/Dockerfile
+++ b/deployments/roman/image/Dockerfile
@@ -86,10 +86,10 @@ USER root
 # remove this step once nbgitpuller enabled; these contents will be in the
 #  jupyterhub-user-content repo.   Install deployment-specific $HOME files.
 COPY default-home-contents/  /etc/default-home-contents
-RUN  cp -r /home/jovyan/.local  /etc/default-home-contents && \
+RUN  cp -r /home/jovyan/.local /etc/default-home-contents && \
      cp -r /home/jovyan/.jupyter /etc/default-home-contents
 COPY global_bashrc  /home/jovyan
-RUN  cat /home/jovyan/global_bashrc   >> /etc/bash.bashrc  && \
+RUN  cat /home/jovyan/global_bashrc >> /etc/bash.bashrc  && \
      rm /home/jovyan/global_bashrc
 
 # Fix certs in conda for application level SSL, e.g. pass image-test running on CI-node
@@ -102,17 +102,14 @@ COPY --chown=${NB_UID}:${NB_GID} environments/test    /opt/environments/test
 # Install security patches now that build is complete;  potentially this could be done sooner
 RUN apt-get update && \
     apt-get dist-upgrade --yes && \
-    apt-get clean
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # For standalone operation outside JupyterHub,  note that  /etc also includes
 # common home directory files.
 
-RUN tree -a /etc/default-home-contents/
-
 RUN cp -r /etc/default-home-contents/* /home/jovyan && \
     fix-permissions  /home/jovyan
-
-RUN tree -a /home/jovyan
 
 USER $NB_USER
 WORKDIR /home/$NB_USER

--- a/deployments/tike/image/Dockerfile
+++ b/deployments/tike/image/Dockerfile
@@ -90,7 +90,8 @@ COPY --chown=${NB_UID}:${NB_GID} environments/test    /opt/environments/test
 # Install security patches now that build is complete;  potentially this could be done sooner
 RUN apt-get update && \
     apt-get dist-upgrade --yes && \
-    apt-get clean
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # For standalone operation outside JupyterHub,  note that  /etc also includes
 # common home directory files.

--- a/deployments/tike/image/environments/frozen/tess-frozen.yml
+++ b/deployments/tike/image/environments/frozen/tess-frozen.yml
@@ -153,6 +153,7 @@ dependencies:
   - notebook=6.2.0
   - numba=0.53.0
   - numexpr=2.7.3
+  - numpy=1.20.2
   - oauthlib=3.0.1
   - olefile=0.46
   - openjpeg=2.4.0
@@ -208,7 +209,6 @@ dependencies:
   - ruamel_yaml=0.15.80
   - scikit-image=0.18.1
   - scikit-learn=0.24.1
-  - scipy=1.6.1
   - seaborn=0.11.1
   - seaborn-base=0.11.1
   - send2trash=1.5.0
@@ -271,13 +271,13 @@ dependencies:
     - astunparse==1.6.3
     - async-timeout==3.0.1
     - autograd==1.3
-    - awscli==1.19.50
+    - awscli==1.19.52
     - batman-package==2.4.7
     - black==20.8b1
     - blessings==1.7
     - bls-py==0.1.2
-    - boto3==1.17.50
-    - botocore==1.20.50
+    - boto3==1.17.52
+    - botocore==1.20.52
     - bs4==0.0.1
     - cachetools==4.2.1
     - celerite==0.4.0
@@ -307,14 +307,14 @@ dependencies:
     - google-auth==1.28.1
     - google-auth-oauthlib==0.4.4
     - google-pasta==0.2.0
-    - grpcio==1.32.0
+    - grpcio==1.37.0
     - h5py==2.10.0
     - html5lib==1.1
     - imagesize==1.2.0
     - iniconfig==1.1.1
     - ipyfilechooser==0.4.3
     - ipygoldenlayout==0.3.0
-    - ipysplitpanes==0.1.0
+    - ipysplitpanes==0.1.0a0
     - jax==0.2.12
     - jaxlib==0.1.65
     - jeepney==0.6.0
@@ -342,11 +342,10 @@ dependencies:
     - nbgitpuller==0.9.0
     - nbsphinx==0.8.3
     - netcdf4==1.5.6
-    - numpy==1.19.5
     - numpydoc==1.1.0
     - oktopus==0.1.2
     - opt-einsum==3.3.0
-    - panel==0.11.2
+    - panel==0.11.3
     - papermill==2.3.3
     - param==1.10.1
     - pathspec==0.8.1
@@ -383,7 +382,8 @@ dependencies:
     - requests-oauthlib==1.3.0
     - retrying==1.3.3
     - rsa==4.7.2
-    - s3transfer==0.3.6
+    - s3transfer==0.3.7
+    - scipy==1.4.1
     - secretstorage==3.3.1
     - semver==2.13.0
     - simpervisor==0.4
@@ -404,10 +404,10 @@ dependencies:
     - stsci-rtd-theme==0.0.2
     - tele-scope==1.0.5
     - tenacity==7.0.0
-    - tensorboard==2.4.1
+    - tensorboard==2.2.2
     - tensorboard-plugin-wit==1.8.0
-    - tensorflow==2.4.1
-    - tensorflow-estimator==2.4.0
+    - tensorflow==2.2.0
+    - tensorflow-estimator==2.2.0
     - termcolor==1.1.0
     - tess-point==0.6.1
     - text-unidecode==1.3
@@ -418,7 +418,7 @@ dependencies:
     - tvguide==1.0.3
     - typed-ast==1.4.3
     - ultranest==3.2.0
-    - uncertainties==2.4.4
+    - uncertainties==3.1.5
     - vaneska==0.0.dev0
     - werkzeug==1.0.1
     - wotan==1.9

--- a/deployments/tike/image/environments/tess/tess.pip
+++ b/deployments/tike/image/environments/tess/tess.pip
@@ -35,7 +35,7 @@ seaborn
 wotan
 dask
 cython
-numpy
+numpy>=1.20
 astropy
 plotly
 pymc3

--- a/deployments/tike/image/environments/tess/tests/imports
+++ b/deployments/tike/image/environments/tess/tests/imports
@@ -30,4 +30,4 @@ batman
 tvguide
 astrobase
 reproject
-starry
+#starry

--- a/setup-env.template
+++ b/setup-env.template
@@ -13,7 +13,7 @@ export IMAGE_TAG=latest
 export COMMON_TAG=common-latest
 
 # sandbox, dev, test, or prod
-export ENVIRONMENT=XXX
+export ENVIRONMENT=sandbox
 
 # ----------------- vvvv less frequently changed vvvv -------------------------------
 
@@ -24,7 +24,7 @@ export USE_FROZEN=1
 export PERSONAL_IMAGE=0
 
 # Additional parameters for image-exec Docker run command, e.g. add mounts here
-export IMAGE_RUN_PARS="--rm -p 8888:8888 -it"
+export IMAGE_RUN_PARS="--rm -e JUPYTER_ENABLE_LAB=yes"
 
 # Image scanning,  report Ubuntu status for this version of Ubuntu
 export IMAGE_UBUNTU_NAME="Focal"

--- a/tools/image-build
+++ b/tools/image-build
@@ -15,15 +15,21 @@ cd ${COMMON_DIR}
 
 # git rev-parse HEAD > common-image-git-hash
 echo "========================= Building Common Image ========================"
+
+# DOCKER_BUILDKIT=1 mentioned here:
+# https://stackoverflow.com/questions/51115856/docker-failed-to-export-image-failed-to-create-image-failed-to-get-layer
+# as a solution to build fail like:
+# failed to export image: failed to create image: failed to get layer sha256:...: layer does not exist
+
 # common image doesn't currently exploit frozen
-time docker build --tag ${COMMON_ID} --build-arg USE_FROZEN=${USE_FROZEN} .
+time   DOCKER_BUILDKIT=1  docker build --tag ${COMMON_ID} --build-arg USE_FROZEN=${USE_FROZEN} .
 
 cd ${IMAGE_DIR}
 
 # git rev-parse HEAD > mission-image-git-hash
 
 echo "========================= Building $IMAGE_ID USE_FROZEN=${USE_FROZEN} =========================="
-time docker build --tag ${IMAGE_ID} --build-arg USE_FROZEN=${USE_FROZEN} --build-arg BASE_IMAGE=${COMMON_ID} .
+time  DOCKER_BUILDKIT=1  docker build --tag ${IMAGE_ID} --build-arg USE_FROZEN=${USE_FROZEN} --build-arg BASE_IMAGE=${COMMON_ID} .
 
 if [[ "$USE_FROZEN" == "0" ]]; then
     echo "========================= Freezing Requirements =========================="

--- a/tools/image-configure
+++ b/tools/image-configure
@@ -1,0 +1,15 @@
+#! /bin/bash -eu
+
+
+cp   setup-env.template   setup-env
+
+DEPLOYMENT_NAME=$1
+perl -pi -e "s/DEPLOYMENT_NAME=cluster-name/DEPLOYMENT_NAME=$DEPLOYMENT_NAME/g" setup-env
+
+USE_FROZEN=${2:-0}
+perl -pi -e "s/USE_FROZEN=[\d]/USE_FROZEN=$USE_FROZEN/g" setup-env
+
+perl -pi -e "s/PERSONAL_IMAGE=[\d]/PERSONAL_IMAGE=1/g" setup-env
+
+
+cat  setup-env

--- a/tools/image-sh
+++ b/tools/image-sh
@@ -3,4 +3,6 @@
 # Run a bash shell in the last tagged mission container.  This will lag
 # behind any partially built container with newer image layers.
 
+IMAGE_RUN_PARS="$IMAGE_RUN_PARS -it"
+
 image-exec /bin/bash --rcfile /etc/bash.bashrc

--- a/tools/run-lab
+++ b/tools/run-lab
@@ -1,5 +1,7 @@
 #! /bin/sh -eu
 
-IMAGE_RUN_PARS="$IMAGE_RUN_PARS -e JUPYTER_ENABLE_LAB=yes"
+# convenience script for running a standalone lab session on localhost:8888
+
+export IMAGE_RUN_PARS="$IMAGE_RUN_PARS -p 8888:8888"
 
 exec image-exec  $*

--- a/tools/source-scan
+++ b/tools/source-scan
@@ -1,0 +1,3 @@
+#! /bin/bash -eu
+
+echo "Scanning source code for vulnerabilities"


### PR DESCRIPTION
Added basic build + test GitHub workflow with both CI environment disk storage recovery and reallocation to 20G swapfile.
Added image-configure to support simple generation of setup-env for use in CI/CD systems.
Revised IMAGE_RUN_PARS setting so that appropriate switches are sent
    to image-sh, image-exec, and run-lab by default.  Tweaked setup-env.template.
Added empty source-scan entry point.
Added BUILD_KIT=1 to image-build in response to GitHub build failure.
Added COPY --chown in a few places in jwebbinar Dockerfile*
Added globbing to test-notebooks input paths.
Added temporary working dir to test-notebooks, with cleanup.
Updated jwebbinar test notebooks.
Improved env-create, clone, update, cleanup install scripts and apt cleanup code.
Updated tike and roman Dockerfiles for common Dockerfile.trailer changes.
Remove starry from tess import checks since it's not being installed
Constrain tess numpy >= 1.20
Add periodic 7 day CI re-build to github actions.
Limit Actions to PR's or pushes to main.
Updated tess frozen spec,  untested frozen build.
Added git diff action to show frozen spec updates.
