### PR TITLE
Fix image-update

### DIFF
--- a/tools/image-update
+++ b/tools/image-update
@@ -1,4 +1,4 @@
-# /bin/bash -eu
+#! /bin/bash -eu
 
 # Update the configured deployment based on files stored in the commmon
 # deployment.


### PR DESCRIPTION
Fix missing "!" in the image-update shebang theoretically missing since October.  Not sure why this has been working well enough nobody noticed...  but on OS-X there are at least some times it silently fails and does nothing.
