### PR TITLE
Add image-patch

### DIFF
--- a/.github/workflows/image-build-test-scan.yml
+++ b/.github/workflows/image-build-test-scan.yml
@@ -1,13 +1,13 @@
 name:  Image Build, Test, Scan
 on:
-   schedule:
-     - cron: '0 0 */7 * *'
+   schedule:  # weekly
+     - cron: '0 0 * * 0'
    push:
-      # branches:
-      #   - main
+      branches:
+        - main
    pull_request:
-      # branches:
-      #   - main
+      branches:
+        - main
 
 jobs:
   docker:

--- a/.github/workflows/source-code-scanning.yml
+++ b/.github/workflows/source-code-scanning.yml
@@ -1,13 +1,13 @@
 name: Source Code Scanning
 on:
-   schedule:
-     - cron: '0 0 */7 * *'
+   schedule: # weekly
+     - cron: '0 0 * * 0'
    push:
-      # branches:
-      #   - main
+      branches:
+        - main
    pull_request:
-      # branches:
-      #   - main
+      branches:
+        - main
 
 jobs:
   source-scanning:

--- a/deployments/common/image/Dockerfile.trailer
+++ b/deployments/common/image/Dockerfile.trailer
@@ -28,10 +28,10 @@ RUN /opt/common-scripts/fix-certs
 COPY --chown=${NB_UID}:${NB_GID} environments/test    /opt/environments/test
 
 # Install security patches now that build is complete;  potentially this could be done sooner
-RUN apt-get update && \
-    apt-get dist-upgrade --yes && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+# -- RUN apt-get update && \
+# --     apt-get dist-upgrade --yes && \
+# --     apt-get clean && \
+# --     rm -rf /var/lib/apt/lists/*
 
 # For standalone operation outside JupyterHub,  note that  /etc also includes
 # common home directory files.

--- a/deployments/jwebbinar/image/Dockerfile
+++ b/deployments/jwebbinar/image/Dockerfile
@@ -143,10 +143,10 @@ RUN /opt/common-scripts/fix-certs
 COPY --chown=${NB_UID}:${NB_GID} environments/test    /opt/environments/test
 
 # Install security patches now that build is complete;  potentially this could be done sooner
-RUN apt-get update && \
-    apt-get dist-upgrade --yes && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+# -- RUN apt-get update && \
+# --     apt-get dist-upgrade --yes && \
+# --     apt-get clean && \
+# --     rm -rf /var/lib/apt/lists/*
 
 # For standalone operation outside JupyterHub,  note that  /etc also includes
 # common home directory files.

--- a/deployments/roman/image/Dockerfile
+++ b/deployments/roman/image/Dockerfile
@@ -100,10 +100,10 @@ RUN /opt/common-scripts/fix-certs
 COPY --chown=${NB_UID}:${NB_GID} environments/test    /opt/environments/test
 
 # Install security patches now that build is complete;  potentially this could be done sooner
-RUN apt-get update && \
-    apt-get dist-upgrade --yes && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+# -- RUN apt-get update && \
+# --     apt-get dist-upgrade --yes && \
+# --     apt-get clean && \
+# --     rm -rf /var/lib/apt/lists/*
 
 # For standalone operation outside JupyterHub,  note that  /etc also includes
 # common home directory files.

--- a/deployments/tike/image/Dockerfile
+++ b/deployments/tike/image/Dockerfile
@@ -88,10 +88,10 @@ RUN /opt/common-scripts/fix-certs
 COPY --chown=${NB_UID}:${NB_GID} environments/test    /opt/environments/test
 
 # Install security patches now that build is complete;  potentially this could be done sooner
-RUN apt-get update && \
-    apt-get dist-upgrade --yes && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+# -- RUN apt-get update && \
+# --     apt-get dist-upgrade --yes && \
+# --     apt-get clean && \
+# --     rm -rf /var/lib/apt/lists/*
 
 # For standalone operation outside JupyterHub,  note that  /etc also includes
 # common home directory files.

--- a/doc/SCRIPTS.md
+++ b/doc/SCRIPTS.md
@@ -1,5 +1,13 @@
 # In the `tools` directory, there are a series of convenience scripts.
 
+#### Dependencies
+
+In theory they're automatically installed on all new CI-nodes, but if not you
+need to install Python dependencies before executing some of these scripts.
+
+```
+pip install --cert /etc/ssl/certs/ca-bundle.crt -r requirements.txt
+```
 
 #### Image management scripts
 
@@ -9,18 +17,19 @@ Scripts have been added to the *tools* directory to simplify image development:
 - image-test    -- experimental,  run autmatic image tests.  requires added support in deployment
 - image-push    -- push the built + tested Docker image to ECR at the configured tag
 - image-sh      -- start a container running an interactive bash shell for poking around
+- image-root-sh -- start a container running an interactive bash shell as root
 - image-exec    -- start a container and run an arbitrary command
 - image-all     -- build, test, and push the image.
+- image-login   -- log in to ECR
+- image-configure  -- set up for CI and/or local builds not pushed anywhere
+- image-freeze  -- dump out frozen environment specs from the current image into deployments tree.
+- image-update  -- as part of building, generate any required Dockerfiles, obtain current SSL certs, etc.
 
-**TODO**: update this list of scripts^^
-
-Sourcing *setup-env* should add these scripts to your path, they require no parameters.
+Sourcing *setup-env* should add these scripts to your path, they generally require no parameters.
 
 Using the scripts is simple, basically some iterative flow of:
 
 ```
-# Update deployment Dockerfile in deployments/<your-deployment>/image.
-
 # Build the Docker image
 tools/image-build
 
@@ -30,11 +39,20 @@ tools/image-test
 
 # Push the completed image to ECR for use on the hub,  proceed to Helm based JupyterHub deployment
 tools/image-push
+
+# Check the ECR scan report and report status and/or vulnerabilities
+tools/image-scan
 ```
 
 #### Scripts to automate ECR scan results
 
+Our ECR is currently terraform'ed to run the AWS image scanner whenever a new
+image is pushed to the repo.
+
 ```
+# One-stop ECR results check:  downloads results, follows up with Ubuntu, prints summary
+image-scan
+
 # Fetch results from ECR,  fetch Ubuntu CVE response status, print combined
 # results as YAML
 image-scan-report   <ubuntu version name sub-string>   <minimum severity level>    > report.yaml
@@ -44,14 +62,11 @@ image-scan-report   Focal   medium   >report.yaml
 image-scan-summarize  report.yaml
 ```
 
-You may need to install Python dependency before executing the *image-scan-xxx* scripts:
-```
-pip install --cert /etc/ssl/certs/ca-bundle.crt -r requirements.txt
-```
-
 #### Secrets convenience scripts
 
-Once you've terraform'd your secrets repo and know your way around, these convenience scripts may help you check out and update your secrets based on your configured environment.
+Once you've terraform'd your secrets repo and know your way around, these
+convenience scripts may help you check out and update your secrets based on
+your configured environment.
 
 ```
 # Clone your code commit secrets repo.  Note that this repo should never be added directly to jupyterhub-deploy.
@@ -67,3 +82,123 @@ secrets-push
 # clone and pushes.  Called automatically.
 secrets-get-exports
 ```
+
+
+#### CI Source Code Scanning Scripts
+
+As part of CI we run source code scanners which check both our own Python code
+and the Python dependencies in the mission images.  These scripts are
+independent of the functional CI tests and do note require building an image
+prior to running.
+
+```
+# One stop dev shopping,  run all source code scans on the current sources
+sscan
+
+# Run Python's bandit package on any discoverable Python code
+sscan-bandit
+
+# Run Python's safety package to check dependencies of the conda environments
+# of the current image for vulnerabilities
+sscan-safety
+```
+
+
+#### Image Patching
+
+The `image-patch` script is used to create a new version of an image which
+results from executing a caller-supplied script.  It basically works as
+follows:
+
+1. Unless overridden, the current image defined in setup-env is used as a
+source image for the patch.  It is assumed that the source image is already
+available locally.  See `docker-wipe` and `image-pull` for setting up Docker
+using an existing image from ECR instead of doing a full build using
+`image-build`.  Note that the tags are the same but a patch source image is in
+some sense "old".  Throughout the patching process,  actions occur inside
+a container started from this source image.
+
+2. The /opt/patches/<source-image-hash> directory is used to hold history
+metadata for this particular patch.  Multiple patches can be applied in
+sequence and each patch will store metadata in a directory named for it's
+source image.  The directory and file dates show the order of patching.
+Metadata describing the source image, patch metadata and script, and patch log
+are eventually stored here as part of the patched image.
+
+3. The patch script is executed inside the container to do the real work of the
+patch, leaving behind side effects in the current container's file system
+layer.  These side effects need to be limited to the primary file system of the
+container, i.e. no changes to extra volumes, etc. mounted inside the container.
+The patch script can be anything executable, e.g. a bash script performing an
+Ubuntu upgrde (`tools/apt-upgrade`), a script installing or removing a package,
+etc.  The log from the patch script is captured and copied into the patch.log
+file in the patch history directory inside the patch container.
+
+4. The patch container is used to generate a new version of the image using
+`docker commit`.  This image only exists locally but is ready to be pushed to
+ECR using `image-push`.  Run `image-test` before pushing back to ECR,  there
+is no automatic CI as part of this process.
+
+A full patch workflow might look like:
+
+```
+# Set up environment defining tagged operational ECR image $IMAGE_ID
+source setup-env
+
+# Clear out Docker so $IMAGE_ID is unequivocally coming from ECR
+docker-wipe
+
+# Pull the operartional $IMAGE_ID image out of ECR for patching
+image-pull
+
+# Use and existing patch script (e.g. tools/apt-upgrade) or create a new one.
+
+# Apply the patch script creating new version of $IMAGE_ID
+image-patch   tools/apt-upgrade     jmiller@stsci.edu   "Apply Ubuntu security updates."
+
+# Run CI tests on the patched image to make sure no disasters occurred
+image-test
+
+# Push the patched image back to ECR as same tag $IMAGE_ID
+image-push
+
+# Perform interactive notebook tests on the live hub
+...
+```
+
+To investigate patches in an operational image something like the following
+is in order:
+
+```
+# Set up environment defining tagged operational ECR image $IMAGE_ID
+source setup-env
+
+# Clear out Docker so $IMAGE_ID is unequivocally coming from ECR
+docker-wipe
+
+# Pull the operartional $IMAGE_ID image out of ECR for inspection
+image-pull
+
+# Run a shell on the image and poke around
+image-root-sh
+cd /opt/patches/<src-image-hash>
+cat metadata.yaml
+...
+```
+
+**Patching NOTES:**
+
+- `image-patch` should be used sparingly when the risk of accidentally breaking
+an operational image functionally by rebuilding normally is unacceptable.
+Example uses might be application of needed security updates or small
+corrections or additions to conda environments applied to formal releases.
+
+- As-is, this workflow is essentially replacing the operational image without
+doing much external record keeping.  The new operational image records where it
+came from and how in the /opt/patches/... history directories *inside* the
+image.  Once the new image is pushed, the source image effectively becomes
+anonymous unless tagged with a scheme outside this scope prior to patching and
+pushing.
+
+- Using `docker-wipe` will destroy all existing images and containers in the
+Docker environment in preparation for pulling down the operational image.

--- a/tools/apt-upgrade
+++ b/tools/apt-upgrade
@@ -1,0 +1,8 @@
+#! /bin/bash
+
+# Ubuntu update script for patching images
+
+apt-get update --yes &&
+DEBIAN_FRONTEND=noninteractive apt-get dist-upgrade --yes && \
+apt-get clean && \
+rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/tools/image-patch
+++ b/tools/image-patch
@@ -1,0 +1,82 @@
+
+#! /bin/bash -eu
+
+# This script is used to generate a new version of an existing image by running
+# a patch script inside a container created from the image.  The container is
+# then commited using "docker commit ..." to store it's writable layer in a new
+# image.   See doc/SCRIPTS.md for more info on using this script.
+#
+# WARNING: use this sparingly because the transparency of the image build is
+# more limited than a Dockerfile based build.
+#
+# WARNING: this script starts with the local image defined by setup-env and
+# eventually replaces that tag with the patched image.  The original image continues
+# to exist and is part of the patched image...  but it is no longer tagged that way.
+
+if [ $# -lt 3 ]; then
+    echo "usage:  patch-image  patch-script   admin-email   description  [source-image-hash]"
+    exit 2
+fi
+
+PATCH_FILE=$1
+ADMIN_EMAIL=$2
+DESCRIPTION=$3
+
+# By default,  use the hash of $IMAGE_ID as defined in setup-env for source image
+IMAGE_HASH=` docker image ls ${IMAGE_ID} | tail -1 | awk '{ print $3; }'`
+
+# Otherwise use the value of the 4th parameter as the hash of the source image
+SRC_HASH=${4:-${IMAGE_HASH}}
+
+PATCH_DIR=/opt/patches/${SRC_HASH}
+INSTALLED_PATCH=${PATCH_DIR}/`basename $PATCH_FILE`
+
+PATCH_CONTAINER=image-patched
+
+# -----------------------------------------------------------------------------------
+docker container rm -f ${PATCH_CONTAINER}  >& /dev/null
+
+# Start a container to use as a target for cp and exec;  use sleep to keep it running.
+echo "========= Starting container ${PATCH_CONTAINER} from image ${SRC_HASH}"
+docker run -d --name ${PATCH_CONTAINER} ${SRC_HASH} /bin/sleep 3600000  >& /dev/null
+
+# Inside container,  create patch history directory specific to source image.
+echo "========= Creating patch directory ${PATCH_DIR} in container ${PATCH_CONTAINER}"
+docker container exec --user root ${PATCH_CONTAINER} /bin/mkdir -p ${PATCH_DIR}
+
+# Store docker inspect output for source image in container
+echo "========= Storing 'docker inspect ${SRC_HASH}' in container as ${PATCH_DIR}/source-inspect.json"
+docker inspect ${SRC_HASH} > source-inspect.json
+docker container cp source-inspect.json ${PATCH_CONTAINER}:${PATCH_DIR}/source-inspect.json
+rm source-inspect.json
+
+# Store metadata for patch in history directory for this patch
+echo "========= Storing patch metadata in container as ${PATCH_DIR}/metadata.yaml"
+cat >metadata.yaml  <<EOF
+author: "${ADMIN_EMAIL}"
+description: "${DESCRIPTION}"
+EOF
+docker container cp metadata.yaml ${PATCH_CONTAINER}:${PATCH_DIR}/metadata.yaml
+rm metadata.yaml
+
+# Store the patch script in the container history directory for this patch
+echo "========= Copying script ${PATCH_FILE} into container as ${INSTALLED_PATCH}"
+docker container cp $PATCH_FILE   ${PATCH_CONTAINER}:$INSTALLED_PATCH
+
+# Execute the patch script inside the container and capture log output to patch.log
+echo "========= Executing script ${PATCH_FILE} in container, logging to ${PATCH_DIR}/patch.log"
+docker container exec --user root --workdir ${PATCH_DIR}  ${PATCH_CONTAINER}  /bin/bash -x ${INSTALLED_PATCH}  2>&1 | tee patch.log
+docker container cp patch.log ${PATCH_CONTAINER}:${PATCH_DIR}/patch.log
+rm patch.log
+
+# Make sure final user is jovyan again
+echo "========== Reverting current user in container to jovyan"
+docker container exec --user root ${PATCH_CONTAINER}  su jovyan
+
+# Snapshot the side effects from exec and cp into a new image with the old tag.
+echo "========== Saving container ${PATCH_CONTAINER} in new image ${IMAGE_ID}"
+docker commit  -a "${ADMIN_EMAIL}" -m "${DESCRIPTION}"  --change 'CMD ["start-notebook.sh"]'  ${PATCH_CONTAINER}  ${IMAGE_ID}   >& /dev/null
+
+# Stop and remove the container used to create the patch image.
+echo "========== Stopping and removing container ${PATCH_CONTAINER}"
+docker container rm -f ${PATCH_CONTAINER} >& /dev/null

--- a/tools/image-pull
+++ b/tools/image-pull
@@ -1,0 +1,9 @@
+#! /bin/bash
+
+cd $IMAGE_DIR
+
+image-login
+
+echo "================================== Pulling ${IMAGE_ID} =============================="
+docker image rm $IMAGE_ID
+docker pull $IMAGE_ID

--- a/tools/image-push
+++ b/tools/image-push
@@ -1,12 +1,14 @@
 #! /bin/bash -eu
 
-# Log into the container registry and push the current image.
+# Log into the container registry and push the current image
 
 cd $IMAGE_DIR
 
 image-login
 
-# docker push ${COMMON_ID}
+UNSCANNED_ID=`echo $IMAGE_ID | perl -pi -e 's/:latest/:unscanned-latest/g'`
 
-echo "================================== Pushing ${IMAGE_ID} =============================="
-docker push ${IMAGE_ID}
+echo "================================== Pushing ${IMAGE_ID} as ${UNSCANNED_ID} =============================="
+# docker image tag $IMAGE_ID $UNSCANNED_ID
+# docker push ${UNSCANNED_ID}
+docker push ${IMAGE_ID}       # XXX comment out / remove this once ITSD quarantine scheme is in place.


### PR DESCRIPTION
Removed apt-get dist-upgrade from Dockerfile.trailer since the need for
  it is offset by (a) building scipy-notebook from source ourselves and
  (b) supporting patch images which can *optionally* do the same thing.
Updated mission Dockerfiles for new Dockerfile.trailer w/o apt-get
dist-upgrade.
Added basic image-patch and image-pull scripts.
Modified image-push anticipating ITSD quarantine scheme.
Updated CI actions to run on PR or push/merge to main branch only.
Updated CI periodic run to weekly (vs whatever it was doing).
Updated docs in general,  added info on patching.