### PR TITLE
Fix ds9 cache busting

### DIFF
--- a/tools/image-update
+++ b/tools/image-update
@@ -1,4 +1,6 @@
-#! /bin/bash -eu
+#! /bin/bash -e
+
+set -u
 
 # Update the configured deployment based on files stored in the commmon
 # deployment.
@@ -47,4 +49,5 @@ if [[ $USE_FROZEN == "0" ]]; then
   # echo "Clearing frozen image specs to avoid Docker cache busting."
   # echo "Add or commit them to git prior to unfrozen builds to avoid this clear."
   git checkout -- environments/frozen
+  git checkout -- ../../common/image/environments/frozen
 fi

--- a/tools/image-update
+++ b/tools/image-update
@@ -1,6 +1,6 @@
-#! /bin/bash -e
+#! /bin/bash
 
-set -u
+set -eu
 
 # Update the configured deployment based on files stored in the commmon
 # deployment.


### PR DESCRIPTION
Added common frozen specs to those cleared during image-update to prevent cache busting.

Cache busts only occur when common frozen specs change,  but when they do the build backs up to ds9 to use new versions.