### PR TITLE
Image patching additional scripts

### DIFF
--- a/tools/image-delete
+++ b/tools/image-delete
@@ -1,0 +1,21 @@
+#! /bin/bash
+
+# deletes ECR images simply
+
+set -eu
+
+IMAGES=$*
+
+if [[ "$#" == "0" ]]; then
+    echo "usage: image-delete  <tag-or-ecr-digest>..."
+fi
+
+for image in ${IMAGES}; do
+    if [[ `echo $image | cut -d':' -f1` == "sha256" ]]; then
+       QUALIFIER=imageDigest
+    else
+	QUALIFIER=imageTag
+    fi
+    awsudo ${ADMIN_ARN} aws ecr batch-delete-image --repository-name ${IMAGE_REPO} --image-ids ${QUALIFIER}=${image}
+done
+

--- a/tools/patch-image
+++ b/tools/patch-image
@@ -14,7 +14,7 @@
 # to exist and is part of the patched image...  but it is no longer tagged that way.
 
 if [ $# -lt 3 ]; then
-    echo "usage:  patch-image  patch-script   admin-email   description  [source-image-hash]"
+    echo "usage:  patch-image  <patch-script>   <admin-email>   <description>  [<source-image-hash>]"
     exit 2
 fi
 

--- a/tools/patch-os
+++ b/tools/patch-os
@@ -1,0 +1,21 @@
+#! /bin/bash
+
+set -eu
+
+# This script is used to generate a new version of an existing image after
+# performing an OS update.
+#
+
+if [ $# -lt 1 ]; then
+    echo "usage:  patch-os  <admin-email>   [<description>]  [<source-image-hash>]"
+    exit 2
+fi
+
+ADMIN_EMAIL=$1
+DESCRIPTION=${2:-"OS update"}
+IMAGE_HASH=${3:-""}
+
+# -----------------------------------------------------------------------------------
+cd $JUPYTERHUB_DIR
+
+patch-image  tools/apt-upgrade    "${ADMIN_EMAIL}"   "${DESCRIPTION}"   "${IMAGE_HASH}"

--- a/tools/patch-ssl
+++ b/tools/patch-ssl
@@ -1,0 +1,67 @@
+#! /bin/bash
+
+set -eu
+
+# This script is used to update the SSL certs of existing images using image-patch
+#
+
+if [ $# -lt 1 ]; then
+    echo "usage:  patch-ssl <admin-email>   [<description>]    [<cert-file>|'auto']    [<source-image-hash>]"
+    exit 2
+fi
+
+cd $JUPYTERHUB_DIR
+
+ADMIN_EMAIL=${1:-"dmd_octarine@stsci.edu"}
+DESCRIPTION=${2:-"SSL cert update."}
+CERT_FILE=${3:-"auto"}
+
+# By default,  use the hash of $IMAGE_ID as defined in setup-env for source image
+IMAGE_HASH=` docker image ls ${IMAGE_ID} | tail -1 | awk '{ print $3; }'`
+
+# Otherwise use the value of the 4th parameter as the hash of the source image
+SRC_HASH=${4:-${IMAGE_HASH}}
+
+# ---------------------------------------------------------------------------------
+# If CERT_FILE is "auto" then automatically update and use the cert from common/image
+
+if [[ ${CERT_FILE} == "auto" ]]; then
+   image-update
+   CERT_FILE=${COMMON_DIR}/tls-ca-bundle.pem
+fi
+
+# ---------------------------------------------------------------------------------
+# Construct "self-extracting" cert patch script with embedded cert
+
+cat >patch-cert  <<EOF
+cat >tls-ca-bundle.pem <<END_CERT
+EOF
+
+cat ${CERT_FILE} >>patch-cert
+
+cat >>patch-cert  <<EOF
+END_CERT
+
+function update_cert {
+  target=$1
+  rm -f target
+  ln -s `pwd`/tls-ca-bundle.pem  ${target}
+}
+
+update_cert   /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+update_cert   /etc/ssl/certs/ca-bundle.crt
+update_cert   /etc/ssl/certs/ca-certificates.crt
+update_cert   /usr/lib/ssl/cert.pem
+
+/opt/common-scripts/fix-certs
+
+EOF
+
+chmod +x patch-cert
+
+# ---------------------------------------------------------------------------------
+# Run the cert patch script using patch-image
+
+patch-image   patch-cert    "${ADMIN_EMAIL}"    "${DESCRIPTION}"   "${SRC_HASH}"
+
+rm patch-cert


### PR DESCRIPTION
Added image-delete script for deleting images in ECR using digests or tags.
Renamed to image-patch to patch-image.
Added shortcut scripts patch-os and patch-ssl for the most common patches.
Note that OS patches may break SSL and if so patch-ssl is intended to fix or update certs.