### PR TITLE
Added apt-install script to simplify/standardize apt-installs

### DIFF
--- a/deployments/common/image/Dockerfile
+++ b/deployments/common/image/Dockerfile
@@ -37,10 +37,13 @@ ENV CFLAGS="-fcommon"
 # ------------------------------------------------------------------------
 USER root
 
-# Install apt packages, without any questions asked
+# Breaking into separate runs will build slower but also defines storage
+# consumption in docker history.
+#
+# COPY common-scripts/apt-install  /opt/common-scripts/apt-install
 
-RUN    apt-get update --yes && \
-       DEBIAN_FRONTEND=noninteractive apt-get install --yes \
+# Misc system tools
+RUN /opt/common-scripts/apt-install \
         tree \
         curl \
         wget \
@@ -50,8 +53,10 @@ RUN    apt-get update --yes && \
         ssh \
         htop \
         sysstat \
-        imagemagick \
-        \
+        net-tools
+
+# S/W Development Tools
+RUN /opt/common-scripts/apt-install \
         build-essential \
         gfortran \
         automake \
@@ -68,33 +73,40 @@ RUN    apt-get update --yes && \
         libxslt1-dev \
         python-libxml2 \
         python-dev \
-        python-setuptools \
-        \
+        python-setuptools
+
+# X11 and DS9
+RUN /opt/common-scripts/apt-install \
         dbus-x11 \
-        firefox \
         xfce4 \
         xfce4-panel \
         xfce4-session \
         xfce4-settings \
         xorg \
         xubuntu-icon-theme \
-        \
+        imagemagick \
+        gedit \
+        saods9
+
+# Firefox ???
+RUN /opt/common-scripts/apt-install \
+        firefox
+
+# Libraries for FITS, DS9, ML
+RUN /opt/common-scripts/apt-install \
         file \
         libcfitsio-bin \
         libcfitsio-dev \
         apt-file \
-        texlive-latex-recommended \
-        cm-super \
         libxpa-dev \
         libxt-dev \
         libbz2-dev \
-        nvidia-cuda-toolkit \
-        gedit \
-	saods9 \
-	net-tools \
-        && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+        nvidia-cuda-toolkit
+
+# Latex
+RUN /opt/common-scripts/apt-install \
+        texlive-latex-recommended \
+        cm-super
 
 # ------------------------------------------------------------------------
 # This must be run after conda installs

--- a/deployments/common/image/Dockerfile.certs
+++ b/deployments/common/image/Dockerfile.certs
@@ -6,10 +6,18 @@ USER root
 
 ARG TZ='America/New_York'
 ARG DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && \
-    apt-get install -y tzdata ca-certificates openssl wget vim npm nodejs && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+
+
+COPY common-scripts/apt-install  /opt/common-scripts/apt-install
+RUN /opt/common-scripts/apt-install \
+    tzdata \
+    ca-certificates \
+    openssl \
+    wget \
+    vim \
+    npm \
+    nodejs
 
 # ------------------------------------------------------------------------
 # SSL/TLS cert setup for STScI AWS firewalling

--- a/deployments/common/image/common-scripts/apt-install
+++ b/deployments/common/image/common-scripts/apt-install
@@ -1,0 +1,20 @@
+#! /bin/bash
+
+# Standardize how we install apt packages and cleanup after,  make it easy.
+# 1. Install apt packages, without any questions asked
+# 2. Update pacakge metadata before install
+# 3. Remove unneeded files after install
+
+if [ $# == 0 ];  then
+echo "usage: apt-install <packages...>"
+exit 0
+fi
+
+set -eu
+
+PACKAGES=$*
+
+apt-get update --yes && \
+DEBIAN_FRONTEND=noninteractive apt-get install --yes ${PACKAGES} && \
+apt-get clean && \
+rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/deployments/tike/image/Dockerfile
+++ b/deployments/tike/image/Dockerfile
@@ -92,6 +92,7 @@ RUN chown -R ${NB_UID}:${NB_GID}  /home/${NB_USER}
 RUN sed -i 's/data-base-url="{{base_url | urlencode}}"/data-base-url="{{base_url}}"/g' `ls -1 ${CONDA_DIR}/lib/python*/site-packages/notebook/templates/notebook.html`
 
 # ----------------------------------------------------------------------
+
 USER $NB_UID
 RUN /opt/common-scripts/kernel-setup   # set up Ipython / JupyterLab kernels
 
@@ -104,10 +105,10 @@ USER root
 
 # remove this step once nbgitpuller enabled; these contents will be in the
 #  jupyterhub-user-content repo.   Install deployment-specific $HOME files.
-COPY default-home-contents/  /etc/default-home-contents
+COPY default-home-contents/ /etc/default-home-contents
 RUN  cp -r /home/jovyan/.local /etc/default-home-contents && \
      cp -r /home/jovyan/.jupyter /etc/default-home-contents
-COPY global_bashrc  /home/jovyan
+COPY global_bashrc /home/jovyan
 RUN  cat /home/jovyan/global_bashrc >> /etc/bash.bashrc  && \
      rm /home/jovyan/global_bashrc
 

--- a/deployments/tike/image/environments/frozen/exoplanet-frozen.yml
+++ b/deployments/tike/image/environments/frozen/exoplanet-frozen.yml
@@ -39,12 +39,12 @@ dependencies:
   - xz=5.2.5
   - zlib=1.2.11
   - pip:
-    - absl-py==0.12.0
+    - absl-py==0.13.0
     - aesara-theano-fallback==0.0.4
     - aiohttp==3.7.4.post0
     - alabaster==0.7.12
     - ansiwrap==0.8.4
-    - anyio==3.1.0
+    - anyio==3.2.0
     - appdirs==1.4.4
     - argon2-cffi==20.1.0
     - arviz==0.11.2
@@ -56,19 +56,19 @@ dependencies:
     - async-timeout==3.0.1
     - attrs==21.2.0
     - autograd==1.3
-    - awscli==1.19.87
+    - awscli==1.19.97
     - babel==2.9.1
     - backcall==0.2.0
     - beautifulsoup4==4.9.3
-    - black==21.5b2
+    - black==21.6b0
     - bleach==3.3.0
     - blessings==1.7
     - bokeh==2.3.2
-    - boto3==1.17.87
-    - botocore==1.20.87
+    - boto3==1.17.97
+    - botocore==1.20.97
     - bottleneck==1.3.2
-    - bqplot==0.12.28
-    - bqplot-image-gl==1.4.1
+    - bqplot==0.12.27
+    - bqplot-image-gl==1.4.2
     - cached-property==1.5.2
     - cachetools==4.2.2
     - cffi==1.14.5
@@ -85,11 +85,11 @@ dependencies:
     - cycler==0.10.0
     - cython==0.29.23
     - czech-holidays==0.1.3
-    - dask==2021.5.1
+    - dask==2021.6.1
     - decorator==4.4.2
     - defusedxml==0.7.1
-    - dill==0.3.3
-    - distributed==2021.5.1
+    - dill==0.3.4
+    - distributed==2021.6.1
     - docutils==0.15.2
     - echo==0.5
     - entrypoints==0.3
@@ -102,13 +102,13 @@ dependencies:
     - flake8==3.9.2
     - flatbuffers==1.12
     - freetype-py==2.2.0
-    - fsspec==2021.5.0
+    - fsspec==2021.6.0
     - future==0.18.2
     - gast==0.3.3
     - glue-core==1.0.1
     - glue-jupyter==0.2.2
     - glue-vispy-viewers==1.0.2
-    - google-auth==1.30.1
+    - google-auth==1.31.0
     - google-auth-oauthlib==0.4.4
     - google-pasta==0.2.0
     - greenlet==1.1.0
@@ -123,19 +123,19 @@ dependencies:
     - iniconfig==1.1.1
     - ipydatawidgets==4.2.0
     - ipyevents==0.8.2
-    - ipygoldenlayout==0.3.0
+    - ipygoldenlayout==0.4.0
     - ipykernel==5.5.5
     - ipympl==0.7.0
-    - ipysplitpanes==0.1.0a0
+    - ipysplitpanes==0.2.0
     - ipython==7.24.1
     - ipython-genutils==0.2.0
     - ipyvolume==0.5.2
     - ipyvue==1.5.0
-    - ipyvuetify==1.6.2
+    - ipyvuetify==1.7.0
     - ipywebrtc==0.6.0
     - ipywidgets==7.6.3
     - ipywidgets-bokeh==1.0.2
-    - jax==0.2.13
+    - jax==0.2.14
     - jaxlib==0.1.67
     - jedi==0.18.0
     - jeepney==0.6.0
@@ -201,8 +201,8 @@ dependencies:
     - pipdeptree==2.0.0
     - pluggy==0.13.1
     - prometheus-client==0.11.0
-    - prompt-toolkit==3.0.18
-    - protobuf==3.17.2
+    - prompt-toolkit==3.0.19
+    - protobuf==3.17.3
     - psutil==5.8.0
     - ptyprocess==0.7.0
     - py==1.10.0
@@ -229,7 +229,7 @@ dependencies:
     - python-slugify==5.0.2
     - pythreejs==2.3.0
     - pytz==2021.1
-    - pyviz-comms==2.0.1
+    - pyviz-comms==2.0.2
     - pyvo==1.1
     - pyvodb==1.0
     - pywavelets==1.1.1
@@ -270,7 +270,7 @@ dependencies:
     - sphinxcontrib-jsmath==1.0.1
     - sphinxcontrib-qthelp==1.0.3
     - sphinxcontrib-serializinghtml==1.1.5
-    - sqlalchemy==1.4.17
+    - sqlalchemy==1.4.18
     - starry==1.1.2
     - stsci-rtd-theme==0.0.2
     - tblib==1.7.0
@@ -278,21 +278,21 @@ dependencies:
     - tensorboard==2.5.0
     - tensorboard-data-server==0.6.1
     - tensorboard-plugin-wit==1.8.0
-    - tensorflow==2.4.1
+    - tensorflow==2.4.2
     - tensorflow-estimator==2.4.0
     - termcolor==1.1.0
-    - terminado==0.10.0
+    - terminado==0.10.1
     - testpath==0.5.0
     - text-unidecode==1.3
     - textwrap3==0.9.2
     - theano-pymc==1.1.2
     - threadpoolctl==2.1.0
-    - tifffile==2021.4.8
+    - tifffile==2021.6.14
     - toml==0.10.2
     - toolz==0.11.1
-    - torch==1.8.1
+    - torch==1.9.0
     - tornado==6.1
-    - tqdm==4.61.0
+    - tqdm==4.61.1
     - traitlets==5.0.5
     - traittypes==0.2.1
     - typed-ast==1.4.3
@@ -302,7 +302,7 @@ dependencies:
     - vispy==0.6.6
     - wcwidth==0.2.5
     - webencodings==0.5.1
-    - websocket-client==1.0.1
+    - websocket-client==1.1.0
     - werkzeug==2.0.1
     - widgetsnbextension==3.5.1
     - wrapt==1.12.1

--- a/deployments/tike/image/environments/frozen/tess-frozen.yml
+++ b/deployments/tike/image/environments/frozen/tess-frozen.yml
@@ -40,12 +40,12 @@ dependencies:
   - xz=5.2.5
   - zlib=1.2.11
   - pip:
-    - absl-py==0.12.0
+    - absl-py==0.13.0
     - aiohttp==3.7.4.post0
     - alabaster==0.7.12
     - allesfitter==1.2.4
     - ansiwrap==0.8.4
-    - anyio==3.1.0
+    - anyio==3.2.0
     - appdirs==1.4.4
     - argon2-cffi==20.1.0
     - astor==0.8.1
@@ -59,20 +59,20 @@ dependencies:
     - async-timeout==3.0.1
     - attrs==21.2.0
     - autograd==1.3
-    - awscli==1.19.87
+    - awscli==1.19.97
     - babel==2.9.1
     - backcall==0.2.0
     - batman-package==2.4.8
     - beautifulsoup4==4.9.3
-    - black==21.5b2
+    - black==21.6b0
     - bleach==3.3.0
     - blessings==1.7
     - bokeh==2.3.2
-    - boto3==1.17.87
-    - botocore==1.20.87
+    - boto3==1.17.97
+    - botocore==1.20.97
     - bottleneck==1.3.2
-    - bqplot==0.12.28
-    - bqplot-image-gl==1.4.1
+    - bqplot==0.12.27
+    - bqplot-image-gl==1.4.2
     - cached-property==1.5.2
     - celerite==0.4.0
     - cffi==1.14.5
@@ -88,11 +88,11 @@ dependencies:
     - cycler==0.10.0
     - cython==0.29.23
     - czech-holidays==0.1.3
-    - dask==2021.5.1
+    - dask==2021.6.1
     - decorator==4.4.2
     - defusedxml==0.7.1
-    - dill==0.3.3
-    - distributed==2021.5.1
+    - dill==0.3.4
+    - distributed==2021.6.1
     - docutils==0.15.2
     - dynesty==1.1
     - echo==0.5
@@ -104,7 +104,7 @@ dependencies:
     - fbpca==1.0
     - flake8==3.9.2
     - freetype-py==2.2.0
-    - fsspec==2021.5.0
+    - fsspec==2021.6.0
     - future==0.18.2
     - gast==0.2.2
     - george==0.4.0
@@ -124,15 +124,15 @@ dependencies:
     - iniconfig==1.1.1
     - ipydatawidgets==4.2.0
     - ipyevents==0.8.2
-    - ipygoldenlayout==0.3.0
+    - ipygoldenlayout==0.4.0
     - ipykernel==5.5.5
     - ipympl==0.7.0
-    - ipysplitpanes==0.1.0a0
+    - ipysplitpanes==0.2.0
     - ipython==7.24.1
     - ipython-genutils==0.2.0
     - ipyvolume==0.5.2
     - ipyvue==1.5.0
-    - ipyvuetify==1.6.2
+    - ipyvuetify==1.7.0
     - ipywebrtc==0.6.0
     - ipywidgets==7.6.3
     - ipywidgets-bokeh==1.0.2
@@ -160,7 +160,7 @@ dependencies:
     - keras-preprocessing==1.1.2
     - keyring==23.0.1
     - kiwisolver==1.3.1
-    - lightkurve==2.0.9
+    - lightkurve==2.0.10
     - locket==0.2.1
     - lxml==4.6.3
     - markdown==3.3.4
@@ -204,8 +204,8 @@ dependencies:
     - pipdeptree==2.0.0
     - pluggy==0.13.1
     - prometheus-client==0.11.0
-    - prompt-toolkit==3.0.18
-    - protobuf==3.17.2
+    - prompt-toolkit==3.0.19
+    - protobuf==3.17.3
     - psutil==5.8.0
     - ptyprocess==0.7.0
     - py==1.10.0
@@ -231,7 +231,7 @@ dependencies:
     - python-slugify==5.0.2
     - pythreejs==2.3.0
     - pytz==2021.1
-    - pyviz-comms==2.0.1
+    - pyviz-comms==2.0.2
     - pyvo==1.1
     - pyvodb==1.0
     - pywavelets==1.1.1
@@ -270,7 +270,7 @@ dependencies:
     - sphinxcontrib-jsmath==1.0.1
     - sphinxcontrib-qthelp==1.0.3
     - sphinxcontrib-serializinghtml==1.1.5
-    - sqlalchemy==1.4.17
+    - sqlalchemy==1.4.18
     - stsci-rtd-theme==0.0.2
     - tblib==1.7.0
     - tenacity==7.0.0
@@ -278,18 +278,18 @@ dependencies:
     - tensorflow==1.15.5
     - tensorflow-estimator==1.15.1
     - termcolor==1.1.0
-    - terminado==0.10.0
+    - terminado==0.10.1
     - tess-point==0.6.1
     - testpath==0.5.0
     - text-unidecode==1.3
     - textwrap3==0.9.2
     - threadpoolctl==2.1.0
-    - tifffile==2021.4.8
+    - tifffile==2021.6.14
     - toml==0.10.2
     - toolz==0.11.1
-    - torch==1.8.1
+    - torch==1.9.0
     - tornado==6.1
-    - tqdm==4.61.0
+    - tqdm==4.61.1
     - traitlets==5.0.5
     - traittypes==0.2.1
     - typed-ast==1.4.3
@@ -300,7 +300,7 @@ dependencies:
     - vispy==0.6.6
     - wcwidth==0.2.5
     - webencodings==0.5.1
-    - websocket-client==1.0.1
+    - websocket-client==1.1.0
     - werkzeug==2.0.1
     - widgetsnbextension==3.5.1
     - wrapt==1.12.1

--- a/tools/image-env-export
+++ b/tools/image-env-export
@@ -3,4 +3,4 @@
 # Launch the latest mission image and export the conda environment
 # named $1.
 
-image-exec conda env export --no-build --name $1 | sed -e's/\r//g'
+image-exec conda env export --no-build --name $1


### PR DESCRIPTION
Added apt-install script to simplify apt-get installs with standard
  setup and cleanup based on a simple package list.
Refactored common image apt packages into multiple apt-install's
  revolving around functional topics,  particularly to be able
  to see topic space consumption in docker history.