### PR TITLE
Fix source scanning

### DIFF
--- a/deployments/jwebbinar/image/environments/frozen/jdaviz-frozen.yml
+++ b/deployments/jwebbinar/image/environments/frozen/jdaviz-frozen.yml
@@ -12,35 +12,39 @@ dependencies:
   - backports.functools_lru_cache=1.6.4
   - bleach=3.3.0
   - blosc=1.21.0
+  - bqplot-image-gl=1.4.2
   - brotli=1.0.9
   - brotlipy=0.7.0
   - brunsli=0.1
   - bzip2=1.0.8
+  - c-ares=1.17.1
   - ca-certificates=2021.5.30
   - cffi=1.14.5
+  - cfitsio=3.470
   - chardet=4.0.0
   - charls=2.2.0
   - cloudpickle=1.6.0
   - cryptography=3.4.7
   - cycler=0.10.0
   - cytoolz=0.11.0
+  - debugpy=1.3.0
   - defusedxml=0.7.1
   - entrypoints=0.3
   - freetype=2.10.4
-  - fsspec=2021.6.0
+  - fsspec=2021.6.1
   - giflib=5.2.1
   - idna=2.10
-  - imagecodecs=2021.3.31
+  - imagecodecs=2021.6.8
   - imageio=2.9.0
-  - importlib-metadata=4.5.0
+  - importlib-metadata=4.6.0
   - ipydatawidgets=4.2.0
-  - ipykernel=5.5.5
+  - ipykernel=6.0.0
   - ipympl=0.7.0
-  - ipython=7.24.1
+  - ipython=7.25.0
   - ipython_genutils=0.2.0
   - ipyvolume=0.6.0a8
   - ipyvue=1.5.0
-  - ipyvuetify=1.6.2
+  - ipyvuetify=1.7.0
   - ipywebrtc=0.6.0
   - ipywidgets=7.6.3
   - jbig=2.1
@@ -53,22 +57,28 @@ dependencies:
   - jupyterlab_widgets=1.0.0
   - jxrlib=1.1
   - kiwisolver=1.3.1
+  - krb5=1.19.1
   - lcms2=2.12
-  - ld_impl_linux-64=2.35.1
+  - ld_impl_linux-64=2.36.1
   - lerc=2.2.1
-  - libaec=1.0.4
+  - libaec=1.0.5
   - libblas=3.9.0
   - libcblas=3.9.0
+  - libcurl=7.77.0
   - libdeflate=1.7
+  - libedit=3.1.20191231
+  - libev=4.33
   - libffi=3.3
   - libgcc-ng=9.3.0
   - libgfortran-ng=9.3.0
   - libgfortran5=9.3.0
   - libgomp=9.3.0
   - liblapack=3.9.0
+  - libnghttp2=1.43.0
   - libopenblas=0.3.15
   - libpng=1.6.37
   - libsodium=1.0.18
+  - libssh2=1.9.0
   - libstdcxx-ng=9.3.0
   - libtiff=4.3.0
   - libwebp-base=1.2.0
@@ -78,7 +88,6 @@ dependencies:
   - matplotlib-inline=0.1.2
   - mistune=0.8.4
   - nbclient=0.5.3
-  - nbconvert=6.0.7
   - ncurses=6.2
   - nest-asyncio=1.5.1
   - networkx=2.5
@@ -86,20 +95,19 @@ dependencies:
   - openjpeg=2.4.0
   - openssl=1.1.1k
   - packaging=20.9
-  - pandoc=2.14.0.1
+  - pandoc=2.14.0.3
   - partd=1.2.0
   - pexpect=4.8.0
   - pickleshare=0.7.5
-  - pip=21.1.2
-  - pooch=1.3.0
-  - prompt-toolkit=3.0.18
+  - pip=21.1.3
+  - pooch=1.4.0
   - ptyprocess=0.7.0
   - pycparser=2.20
   - pyopenssl=20.0.1
   - pyparsing=2.4.7
   - pyrsistent=0.17.3
   - pysocks=1.7.1
-  - python=3.9.4
+  - python=3.9.5
   - python-dateutil=2.8.1
   - python_abi=3.9
   - pythreejs=2.3.0
@@ -109,10 +117,9 @@ dependencies:
   - readline=8.1
   - requests=2.25.1
   - scikit-image=0.18.1
-  - send2trash=1.5.0
   - setuptools=49.6.0
   - snappy=1.1.8
-  - sqlite=3.35.5
+  - sqlite=3.36.0
   - tk=8.6.10
   - toolz=0.11.1
   - tornado=6.1
@@ -142,28 +149,26 @@ dependencies:
     - astropy-sphinx-theme==1.1
     - async-timeout==3.0.1
     - attrs==20.3.0
-    - awscli==1.19.89
+    - awscli==1.19.103
     - babel==2.9.1
-    - black==21.5b2
+    - black==21.6b0
     - bokeh==2.3.2
-    - boto3==1.17.89
-    - botocore==1.20.89
+    - boto3==1.17.103
+    - botocore==1.20.103
     - bottleneck==1.3.2
     - bqplot==0.12.27
-    - bqplot-image-gl==1.4.2
     - certifi==2020.12.5
     - ci-watson==0.5
     - click==7.1.2
     - codecov==2.1.11
     - colorama==0.4.3
     - coverage==5.5
-    - crds==11.0.2
-    - cython==0.29.23
+    - crds==11.0.4
     - dask==2021.3.0
     - decorator==4.4.2
     - dill==0.3.3
     - docutils==0.15.2
-    - drizzle==1.13.1
+    - drizzle==1.13.3
     - echo==0.5
     - fast-histogram==0.9
     - filelock==3.0.12
@@ -185,7 +190,7 @@ dependencies:
     - jinja2==2.11.3
     - jmespath==0.10.0
     - joblib==1.0.1
-    - json5==0.9.5
+    - json5==0.9.6
     - jupyter-bokeh==3.0.2
     - jupyter-packaging==0.7.12
     - jupyter-server==1.6.1
@@ -201,6 +206,7 @@ dependencies:
     - multidict==5.1.0
     - mypy-extensions==0.4.3
     - nbclassic==0.3.0
+    - nbconvert==6.0.7
     - nbformat==5.1.2
     - notebook==6.3.0
     - numpy==1.20.1
@@ -216,6 +222,7 @@ dependencies:
     - pipdeptree==2.0.0
     - pluggy==0.13.1
     - prometheus-client==0.9.0
+    - prompt-toolkit==3.0.18
     - psutil==5.8.0
     - py==1.10.0
     - pyasn1==0.4.8
@@ -240,6 +247,7 @@ dependencies:
     - s3transfer==0.4.2
     - scipy==1.6.1
     - semantic-version==2.8.5
+    - send2trash==1.5.0
     - simpervisor==0.4
     - six==1.15.0
     - sniffio==1.2.0
@@ -249,7 +257,7 @@ dependencies:
     - spherical-geometry==1.2.20
     - sphinx==3.5.4
     - sphinx-asdf==0.1.1
-    - sphinx-astropy==1.3
+    - sphinx-astropy==1.4
     - sphinx-automodapi==0.13
     - sphinx-bootstrap-theme==0.7.1
     - sphinx-gallery==0.9.0
@@ -270,7 +278,7 @@ dependencies:
     - textwrap3==0.9.2
     - tifffile==2021.3.17
     - toml==0.10.2
-    - tqdm==4.61.0
+    - tqdm==4.61.1
     - tweakwcs==0.7.2
     - typing-extensions==3.10.0.0
     - urllib3==1.26.4

--- a/deployments/jwebbinar/image/environments/frozen/jwebbinar-frozen.yml
+++ b/deployments/jwebbinar/image/environments/frozen/jwebbinar-frozen.yml
@@ -8,7 +8,7 @@ dependencies:
   - certifi=2021.5.30
   - fftw=3.3.9
   - freetds=1.1.15
-  - ld_impl_linux-64=2.35.1
+  - ld_impl_linux-64=2.36.1
   - libblas=3.9.0
   - libcblas=3.9.0
   - libedit=3.1.20191231
@@ -22,15 +22,15 @@ dependencies:
   - libopenblas=0.3.15
   - libstdcxx-ng=9.3.0
   - ncurses=6.2
-  - numpy=1.20.3
+  - numpy=1.21.0
   - openssl=1.1.1k
-  - pip=21.1.2
+  - pip=21.1.3
   - pyfftw=0.12.0
   - python=3.8.0
   - python_abi=3.8
   - readline=8.1
   - setuptools=49.6.0
-  - sqlite=3.35.5
+  - sqlite=3.36.0
   - tk=8.6.10
   - unixodbc=2.3.9
   - wheel=0.36.2
@@ -40,26 +40,26 @@ dependencies:
     - aiohttp==3.7.4.post0
     - alabaster==0.7.12
     - ansiwrap==0.8.4
-    - anyio==3.1.0
+    - anyio==3.2.1
     - appdirs==1.4.4
     - argon2-cffi==20.1.0
-    - asdf==2.8.0
+    - asdf==2.8.1
     - astropy==4.2.1
     - astropy-sphinx-theme==1.1
-    - astroquery==0.4.3.dev6762
+    - astroquery==0.4.3.dev6859
     - astroscrappy==1.0.8
     - async-generator==1.10
     - async-timeout==3.0.1
     - attrs==21.2.0
-    - awscli==1.19.89
+    - awscli==1.19.103
     - babel==2.9.1
     - backcall==0.2.0
     - beautifulsoup4==4.9.3
-    - black==21.5b2
+    - black==21.6b0
     - bleach==3.3.0
     - bokeh==2.3.2
-    - boto3==1.17.89
-    - botocore==1.20.89
+    - boto3==1.17.103
+    - botocore==1.20.103
     - bottleneck==1.3.2
     - bqplot==0.12.27
     - bqplot-image-gl==1.4.2
@@ -70,15 +70,16 @@ dependencies:
     - codecov==2.1.11
     - colorama==0.4.3
     - coverage==5.5
-    - crds==11.0.2
+    - crds==11.0.4
     - cryptography==3.4.7
     - cycler==0.10.0
     - cython==0.29.23
+    - debugpy==1.3.0
     - decorator==4.4.2
     - defusedxml==0.7.1
-    - dill==0.3.3
+    - dill==0.3.4
     - docutils==0.15.2
-    - drizzle==1.13.1
+    - drizzle==1.13.3
     - dust-extinction==1.0
     - echo==0.5
     - entrypoints==0.3
@@ -93,14 +94,15 @@ dependencies:
     - glue-jupyter==0.2.2
     - glue-vispy-viewers==1.0.2
     - gwcs==0.16.1
-    - h5py==3.2.1
-    - healpy==1.14.0
+    - h5py==3.3.0
+    - healpy==1.15.0
+    - hsluv==5.0.2
     - html5lib==1.1
     - idna==2.10
     - imageio==2.9.0
     - imagesize==1.2.0
-    - importlib-metadata==4.5.0
-    - importlib-resources==5.1.4
+    - importlib-metadata==4.6.0
+    - importlib-resources==5.2.0
     - iniconfig==1.1.1
     - ipydatawidgets==4.2.0
     - ipyevents==0.8.2
@@ -112,7 +114,7 @@ dependencies:
     - ipython-genutils==0.2.0
     - ipyvolume==0.5.2
     - ipyvue==1.5.0
-    - ipyvuetify==1.6.2
+    - ipyvuetify==1.7.0
     - ipywebrtc==0.6.0
     - ipywidgets==7.6.3
     - ipywidgets-bokeh==1.0.2
@@ -122,13 +124,13 @@ dependencies:
     - jmespath==0.10.0
     - joblib==1.0.1
     - jplephem==2.15
-    - json5==0.9.5
+    - json5==0.9.6
     - jsonschema==3.2.0
     - jupyter-bokeh==3.0.2
     - jupyter-client==6.1.12
     - jupyter-core==4.7.1
     - jupyter-packaging==0.7.12
-    - jupyter-server==1.8.0
+    - jupyter-server==1.9.0
     - jupyter-server-proxy==3.0.2
     - jupyterlab==3.0.12
     - jupyterlab-pygments==0.1.2
@@ -154,7 +156,7 @@ dependencies:
     - mypy-extensions==0.4.3
     - nbclassic==0.3.1
     - nbclient==0.5.3
-    - nbconvert==6.0.7
+    - nbconvert==6.1.0
     - nbformat==5.1.3
     - nest-asyncio==1.5.1
     - networkx==2.5.1
@@ -162,8 +164,8 @@ dependencies:
     - numpydoc==1.1.0
     - openpyxl==3.0.7
     - packaging==20.9
-    - pandas==1.2.4
-    - pandeia-engine==1.6
+    - pandas==1.2.5
+    - pandeia-engine==1.6.1
     - pandocfilters==1.4.3
     - pandokia==2.3.0
     - papermill==2.3.3
@@ -173,12 +175,12 @@ dependencies:
     - pexpect==4.8.0
     - photutils==1.1.0
     - pickleshare==0.7.5
-    - pillow==8.2.0
+    - pillow==8.3.0
     - pipdeptree==2.0.0
     - pluggy==0.13.1
     - poppy==0.9.2
     - prometheus-client==0.11.0
-    - prompt-toolkit==3.0.18
+    - prompt-toolkit==3.0.19
     - psutil==5.8.0
     - ptyprocess==0.7.0
     - py==1.10.0
@@ -191,9 +193,9 @@ dependencies:
     - pygments==2.9.0
     - pyopengl==3.1.5
     - pyparsing==2.4.7
-    - pyrsistent==0.17.3
+    - pyrsistent==0.18.0
     - pysiaf==0.11.0
-    - pysynphot==1.0.0
+    - pysynphot==1.0.1
     - pytest==6.2.4
     - pytest-cov==2.12.1
     - pytest-doctestplus==0.9.0
@@ -206,19 +208,20 @@ dependencies:
     - pywavelets==1.1.1
     - pyyaml==5.4.1
     - pyzmq==22.1.0
-    - qtconsole==5.1.0
+    - qtconsole==5.1.1
     - qtpy==1.9.0
     - regex==2021.4.4
     - requests==2.25.1
     - requests-mock==1.9.3
+    - requests-unixsocket==0.2.0
     - rsa==4.7.2
     - s3transfer==0.4.2
-    - scikit-image==0.18.1
+    - scikit-image==0.18.2
     - scikit-learn==0.24.2
-    - scipy==1.6.3
+    - scipy==1.7.0
     - secretstorage==3.3.1
     - semantic-version==2.8.5
-    - send2trash==1.5.0
+    - send2trash==1.7.1
     - simpervisor==0.4
     - six==1.16.0
     - sniffio==1.2.0
@@ -227,7 +230,7 @@ dependencies:
     - spherical-geometry==1.2.20
     - sphinx==3.5.4
     - sphinx-asdf==0.1.1
-    - sphinx-astropy==1.3
+    - sphinx-astropy==1.4
     - sphinx-automodapi==0.13
     - sphinx-bootstrap-theme==0.7.1
     - sphinx-gallery==0.9.0
@@ -238,34 +241,34 @@ dependencies:
     - sphinxcontrib-jsmath==1.0.1
     - sphinxcontrib-qthelp==1.0.3
     - sphinxcontrib-serializinghtml==1.1.5
-    - stdatamodels==0.2.1
+    - stdatamodels==0.2.3
     - stpipe==0.2.0
     - stsci-image==2.3.3
     - stsci-imagestats==1.6.2
     - stsci-rtd-theme==0.0.2
     - stsci-stimage==0.2.4
     - stsci-tools==3.6.0
-    - stsynphot==1.0.0
-    - synphot==1.0.1
+    - stsynphot==1.1.0
+    - synphot==1.1.0
     - tenacity==7.0.0
-    - terminado==0.10.0
+    - terminado==0.10.1
     - testpath==0.5.0
     - textwrap3==0.9.2
     - threadpoolctl==2.1.0
-    - tifffile==2021.6.6
+    - tifffile==2021.6.14
     - toml==0.10.2
     - tornado==6.1
-    - tqdm==4.61.0
+    - tqdm==4.61.1
     - traitlets==5.0.5
     - traittypes==0.2.1
     - tweakwcs==0.7.2
     - typing-extensions==3.10.0.0
-    - urllib3==1.26.5
-    - vispy==0.6.6
+    - urllib3==1.26.6
+    - vispy==0.7.0
     - wcwidth==0.2.5
     - webbpsf==0.9.1
     - webencodings==0.5.1
-    - websocket-client==1.0.1
+    - websocket-client==1.1.0
     - widgetsnbextension==3.5.1
     - xlrd==2.0.1
     - yarl==1.6.3

--- a/deployments/jwebbinar/image/environments/setup-notebooks
+++ b/deployments/jwebbinar/image/environments/setup-notebooks
@@ -1,4 +1,4 @@
-s is a standard entry-point used to set up notebooks for this
+# This is a standard entry-point used to set up notebooks for this
 # Docker image.   It is nominally used to pull notebook repos using
 # nbgitpuller and then update the default kernels specified in the
 # notebook files using set-notebook-kernels.

--- a/deployments/tike/image/environments/frozen/exoplanet-frozen.yml
+++ b/deployments/tike/image/environments/frozen/exoplanet-frozen.yml
@@ -8,7 +8,7 @@ dependencies:
   - certifi=2021.5.30
   - fftw=3.3.9
   - freetds=1.1.15
-  - ld_impl_linux-64=2.35.1
+  - ld_impl_linux-64=2.36.1
   - libblas=3.9.0
   - libcblas=3.9.0
   - libedit=3.1.20191231
@@ -26,13 +26,13 @@ dependencies:
   - mkl_fft=1.3.0
   - ncurses=6.2
   - openssl=1.1.1k
-  - pip=21.1.2
+  - pip=21.1.3
   - pyfftw=0.12.0
   - python=3.7.10
   - python_abi=3.7
   - readline=8.1
   - setuptools=49.6.0
-  - sqlite=3.35.5
+  - sqlite=3.36.0
   - tk=8.6.10
   - unixodbc=2.3.9
   - wheel=0.36.2
@@ -44,7 +44,7 @@ dependencies:
     - aiohttp==3.7.4.post0
     - alabaster==0.7.12
     - ansiwrap==0.8.4
-    - anyio==3.2.0
+    - anyio==3.2.1
     - appdirs==1.4.4
     - argon2-cffi==20.1.0
     - arviz==0.11.2
@@ -56,7 +56,7 @@ dependencies:
     - async-timeout==3.0.1
     - attrs==21.2.0
     - autograd==1.3
-    - awscli==1.19.97
+    - awscli==1.19.103
     - babel==2.9.1
     - backcall==0.2.0
     - beautifulsoup4==4.9.3
@@ -64,8 +64,8 @@ dependencies:
     - bleach==3.3.0
     - blessings==1.7
     - bokeh==2.3.2
-    - boto3==1.17.97
-    - botocore==1.20.97
+    - boto3==1.17.103
+    - botocore==1.20.103
     - bottleneck==1.3.2
     - bqplot==0.12.27
     - bqplot-image-gl==1.4.2
@@ -85,15 +85,16 @@ dependencies:
     - cycler==0.10.0
     - cython==0.29.23
     - czech-holidays==0.1.3
-    - dask==2021.6.1
+    - dask==2021.6.2
+    - debugpy==1.3.0
     - decorator==4.4.2
     - defusedxml==0.7.1
     - dill==0.3.4
-    - distributed==2021.6.1
+    - distributed==2021.6.2
     - docutils==0.15.2
     - echo==0.5
     - entrypoints==0.3
-    - exoplanet==0.5.0
+    - exoplanet==0.5.1
     - exoplanet-core==0.1.2
     - fast-histogram==0.9
     - fastprogress==1.0.0
@@ -102,32 +103,33 @@ dependencies:
     - flake8==3.9.2
     - flatbuffers==1.12
     - freetype-py==2.2.0
-    - fsspec==2021.6.0
+    - fsspec==2021.6.1
     - future==0.18.2
     - gast==0.3.3
     - glue-core==1.0.1
     - glue-jupyter==0.2.2
     - glue-vispy-viewers==1.0.2
-    - google-auth==1.31.0
+    - google-auth==1.32.1
     - google-auth-oauthlib==0.4.4
     - google-pasta==0.2.0
     - greenlet==1.1.0
     - grpcio==1.32.0
     - h5py==2.10.0
     - heapdict==1.0.1
+    - hsluv==5.0.2
     - html5lib==1.1
     - idna==2.10
     - imageio==2.9.0
     - imagesize==1.2.0
-    - importlib-metadata==4.5.0
+    - importlib-metadata==3.10.1
     - iniconfig==1.1.1
     - ipydatawidgets==4.2.0
     - ipyevents==0.8.2
     - ipygoldenlayout==0.4.0
-    - ipykernel==5.5.5
+    - ipykernel==6.0.0
     - ipympl==0.7.0
     - ipysplitpanes==0.2.0
-    - ipython==7.24.1
+    - ipython==7.25.0
     - ipython-genutils==0.2.0
     - ipyvolume==0.5.2
     - ipyvue==1.5.0
@@ -135,20 +137,20 @@ dependencies:
     - ipywebrtc==0.6.0
     - ipywidgets==7.6.3
     - ipywidgets-bokeh==1.0.2
-    - jax==0.2.14
-    - jaxlib==0.1.67
+    - jax==0.2.16
+    - jaxlib==0.1.68
     - jedi==0.18.0
     - jeepney==0.6.0
     - jinja2==2.11.3
     - jmespath==0.10.0
     - joblib==1.0.1
-    - json5==0.9.5
+    - json5==0.9.6
     - jsonschema==3.2.0
     - jupyter-bokeh==3.0.2
     - jupyter-client==6.1.12
     - jupyter-core==4.7.1
     - jupyter-packaging==0.7.12
-    - jupyter-server==1.8.0
+    - jupyter-server==1.9.0
     - jupyter-server-proxy==3.0.2
     - jupyterlab==3.0.12
     - jupyterlab-pygments==0.1.2
@@ -174,10 +176,10 @@ dependencies:
     - mypy-extensions==0.4.3
     - nbclassic==0.3.1
     - nbclient==0.5.3
-    - nbconvert==6.0.7
+    - nbconvert==6.1.0
     - nbformat==5.1.3
     - nest-asyncio==1.5.1
-    - netcdf4==1.5.6
+    - netcdf4==1.5.7
     - networkx==2.5.1
     - notebook==6.4.0
     - numpy==1.19.5
@@ -186,7 +188,7 @@ dependencies:
     - oktopus==0.1.2
     - opt-einsum==3.3.0
     - packaging==20.9
-    - pandas==1.2.4
+    - pandas==1.2.5
     - pandocfilters==1.4.3
     - panel==0.11.3
     - papermill==2.3.3
@@ -197,7 +199,7 @@ dependencies:
     - patsy==0.5.1
     - pexpect==4.8.0
     - pickleshare==0.7.5
-    - pillow==8.2.0
+    - pillow==8.3.0
     - pipdeptree==2.0.0
     - pluggy==0.13.1
     - prometheus-client==0.11.0
@@ -220,7 +222,7 @@ dependencies:
     - pymc3-ext==0.1.0
     - pyopengl==3.1.5
     - pyparsing==2.4.7
-    - pyrsistent==0.17.3
+    - pyrsistent==0.18.0
     - pytest==6.2.4
     - pytest-cov==2.12.1
     - pytest-doctestplus==0.9.0
@@ -235,21 +237,22 @@ dependencies:
     - pywavelets==1.1.1
     - pyyaml==5.4.1
     - pyzmq==22.1.0
-    - qtconsole==5.1.0
+    - qtconsole==5.1.1
     - qtpy==1.9.0
     - regex==2021.4.4
     - requests==2.25.1
     - requests-mock==1.9.3
     - requests-oauthlib==1.3.0
+    - requests-unixsocket==0.2.0
     - rsa==4.7.2
     - s3transfer==0.4.2
-    - scikit-image==0.18.1
+    - scikit-image==0.18.2
     - scikit-learn==0.24.2
-    - scipy==1.6.3
+    - scipy==1.7.0
     - seaborn==0.11.1
     - secretstorage==3.3.1
     - semver==2.13.0
-    - send2trash==1.5.0
+    - send2trash==1.7.1
     - setuptools-scm==6.0.1
     - simpervisor==0.4
     - six==1.15.0
@@ -259,7 +262,7 @@ dependencies:
     - soupsieve==2.2.1
     - sphinx==3.5.4
     - sphinx-asdf==0.1.1
-    - sphinx-astropy==1.3
+    - sphinx-astropy==1.4
     - sphinx-automodapi==0.13
     - sphinx-bootstrap-theme==0.7.1
     - sphinx-gallery==0.9.0
@@ -270,7 +273,7 @@ dependencies:
     - sphinxcontrib-jsmath==1.0.1
     - sphinxcontrib-qthelp==1.0.3
     - sphinxcontrib-serializinghtml==1.1.5
-    - sqlalchemy==1.4.18
+    - sqlalchemy==1.4.20
     - starry==1.1.2
     - stsci-rtd-theme==0.0.2
     - tblib==1.7.0
@@ -298,8 +301,8 @@ dependencies:
     - typed-ast==1.4.3
     - typing-extensions==3.7.4.3
     - uncertainties==3.1.5
-    - urllib3==1.26.5
-    - vispy==0.6.6
+    - urllib3==1.26.6
+    - vispy==0.7.0
     - wcwidth==0.2.5
     - webencodings==0.5.1
     - websocket-client==1.1.0

--- a/deployments/tike/image/environments/frozen/tess-frozen.yml
+++ b/deployments/tike/image/environments/frozen/tess-frozen.yml
@@ -8,7 +8,7 @@ dependencies:
   - certifi=2021.5.30
   - fftw=3.3.9
   - freetds=1.1.15
-  - ld_impl_linux-64=2.35.1
+  - ld_impl_linux-64=2.36.1
   - libblas=3.9.0
   - libcblas=3.9.0
   - libedit=3.1.20191231
@@ -26,14 +26,14 @@ dependencies:
   - mkl_fft=1.3.0
   - ncurses=6.2
   - openssl=1.1.1k
-  - pip=21.1.2
+  - pip=21.1.3
   - pyfftw=0.12.0
   - python=3.7.10
   - python_abi=3.7
   - readline=8.1
   - setuptools=49.6.0
   - six=1.16.0
-  - sqlite=3.35.5
+  - sqlite=3.36.0
   - tk=8.6.10
   - unixodbc=2.3.9
   - wheel=0.36.2
@@ -45,7 +45,7 @@ dependencies:
     - alabaster==0.7.12
     - allesfitter==1.2.4
     - ansiwrap==0.8.4
-    - anyio==3.2.0
+    - anyio==3.2.1
     - appdirs==1.4.4
     - argon2-cffi==20.1.0
     - astor==0.8.1
@@ -55,11 +55,12 @@ dependencies:
     - astropy-healpix==0.6
     - astropy-sphinx-theme==1.1
     - astroquery==0.4.2
+    - astunparse==1.6.3
     - async-generator==1.10
     - async-timeout==3.0.1
     - attrs==21.2.0
     - autograd==1.3
-    - awscli==1.19.97
+    - awscli==1.19.103
     - babel==2.9.1
     - backcall==0.2.0
     - batman-package==2.4.8
@@ -68,8 +69,8 @@ dependencies:
     - bleach==3.3.0
     - blessings==1.7
     - bokeh==2.3.2
-    - boto3==1.17.97
-    - botocore==1.20.97
+    - boto3==1.17.103
+    - botocore==1.20.103
     - bottleneck==1.3.2
     - bqplot==0.12.27
     - bqplot-image-gl==1.4.2
@@ -82,53 +83,57 @@ dependencies:
     - cloudpickle==1.6.0
     - codecov==2.1.11
     - colorama==0.4.3
+    - colour==0.1.5
     - corner==2.2.1
     - coverage==5.5
     - cryptography==3.4.7
     - cycler==0.10.0
     - cython==0.29.23
     - czech-holidays==0.1.3
-    - dask==2021.6.1
+    - dask==2021.6.2
+    - debugpy==1.3.0
     - decorator==4.4.2
     - defusedxml==0.7.1
     - dill==0.3.4
-    - distributed==2021.6.1
+    - distributed==2021.6.2
     - docutils==0.15.2
     - dynesty==1.1
     - echo==0.5
     - eleanor==2.0.3
-    - emcee==3.0.2
+    - emcee==3.1.0
     - entrypoints==0.3
     - everest-pipeline==2.0.12
     - fast-histogram==0.9
     - fbpca==1.0
     - flake8==3.9.2
     - freetype-py==2.2.0
-    - fsspec==2021.6.0
+    - fsspec==2021.6.1
     - future==0.18.2
     - gast==0.2.2
+    - geojson==2.5.0
     - george==0.4.0
     - glue-core==1.0.1
     - glue-jupyter==0.2.2
     - glue-vispy-viewers==1.0.2
     - google-pasta==0.2.0
     - greenlet==1.1.0
-    - grpcio==1.38.0
+    - grpcio==1.38.1
     - h5py==2.10.0
     - heapdict==1.0.1
+    - hsluv==5.0.2
     - html5lib==1.1
     - idna==2.10
     - imageio==2.9.0
     - imagesize==1.2.0
-    - importlib-metadata==4.5.0
+    - importlib-metadata==3.10.1
     - iniconfig==1.1.1
     - ipydatawidgets==4.2.0
     - ipyevents==0.8.2
     - ipygoldenlayout==0.4.0
-    - ipykernel==5.5.5
+    - ipykernel==6.0.0
     - ipympl==0.7.0
     - ipysplitpanes==0.2.0
-    - ipython==7.24.1
+    - ipython==7.25.0
     - ipython-genutils==0.2.0
     - ipyvolume==0.5.2
     - ipyvue==1.5.0
@@ -141,14 +146,14 @@ dependencies:
     - jinja2==2.11.3
     - jmespath==0.10.0
     - joblib==1.0.1
-    - json5==0.9.5
+    - json5==0.9.6
     - jsonschema==3.2.0
     - juliet==2.1.2
     - jupyter-bokeh==3.0.2
     - jupyter-client==6.1.12
     - jupyter-core==4.7.1
     - jupyter-packaging==0.7.12
-    - jupyter-server==1.8.0
+    - jupyter-server==1.9.0
     - jupyter-server-proxy==3.0.2
     - jupyterlab==3.0.12
     - jupyterlab-pygments==0.1.2
@@ -177,7 +182,7 @@ dependencies:
     - mypy-extensions==0.4.3
     - nbclassic==0.3.1
     - nbclient==0.5.3
-    - nbconvert==6.0.7
+    - nbconvert==6.1.0
     - nbformat==5.1.3
     - nbsphinx==0.8.6
     - nest-asyncio==1.5.1
@@ -188,7 +193,7 @@ dependencies:
     - oktopus==0.1.2
     - opt-einsum==3.3.0
     - packaging==20.9
-    - pandas==1.2.4
+    - pandas==1.2.5
     - pandocfilters==1.4.3
     - panel==0.11.3
     - papermill==2.3.3
@@ -200,8 +205,9 @@ dependencies:
     - pexpect==4.8.0
     - photutils==1.1.0
     - pickleshare==0.7.5
-    - pillow==8.2.0
+    - pillow==8.3.0
     - pipdeptree==2.0.0
+    - pixiedust==1.1.19
     - pluggy==0.13.1
     - prometheus-client==0.11.0
     - prompt-toolkit==3.0.19
@@ -221,7 +227,7 @@ dependencies:
     - pyopengl==3.1.5
     - pyparsing==2.4.7
     - pypdf2==1.26.0
-    - pyrsistent==0.17.3
+    - pyrsistent==0.18.0
     - pysyzygy==0.0.2
     - pytest==6.2.4
     - pytest-cov==2.12.1
@@ -237,21 +243,22 @@ dependencies:
     - pywavelets==1.1.1
     - pyyaml==5.4.1
     - pyzmq==22.1.0
-    - qtconsole==5.1.0
+    - qtconsole==5.1.1
     - qtpy==1.9.0
     - radvel==1.4.6
     - regex==2021.4.4
     - reproject==0.7.1
     - requests==2.25.1
     - requests-mock==1.9.3
+    - requests-unixsocket==0.2.0
     - rsa==4.7.2
     - s3transfer==0.4.2
-    - scikit-image==0.18.1
+    - scikit-image==0.18.2
     - scikit-learn==0.24.2
-    - scipy==1.6.3
+    - scipy==1.7.0
     - seaborn==0.11.1
     - secretstorage==3.3.1
-    - send2trash==1.5.0
+    - send2trash==1.7.1
     - simpervisor==0.4
     - sniffio==1.2.0
     - snowballstemmer==2.1.0
@@ -259,7 +266,7 @@ dependencies:
     - soupsieve==2.2.1
     - sphinx==3.5.4
     - sphinx-asdf==0.1.1
-    - sphinx-astropy==1.3
+    - sphinx-astropy==1.4
     - sphinx-automodapi==0.13
     - sphinx-bootstrap-theme==0.7.1
     - sphinx-gallery==0.9.0
@@ -270,7 +277,7 @@ dependencies:
     - sphinxcontrib-jsmath==1.0.1
     - sphinxcontrib-qthelp==1.0.3
     - sphinxcontrib-serializinghtml==1.1.5
-    - sqlalchemy==1.4.18
+    - sqlalchemy==1.4.20
     - stsci-rtd-theme==0.0.2
     - tblib==1.7.0
     - tenacity==7.0.0
@@ -294,10 +301,10 @@ dependencies:
     - traittypes==0.2.1
     - typed-ast==1.4.3
     - typing-extensions==3.10.0.0
-    - ultranest==3.2.1
+    - ultranest==3.3.0
     - uncertainties==3.1.5
-    - urllib3==1.26.5
-    - vispy==0.6.6
+    - urllib3==1.26.6
+    - vispy==0.7.0
     - wcwidth==0.2.5
     - webencodings==0.5.1
     - websocket-client==1.1.0

--- a/setup-env.template
+++ b/setup-env.template
@@ -8,7 +8,7 @@
 
 export ACCOUNT_ID=12345678
 export CENTRAL_ECR_ACCOUNT_ID=12345678
-export USE_CENTERAL_ECR=<true | false>
+export USE_CENTERAL_ECR=false
 export ADMIN_ROLENAME=admin-role
 export DEPLOYMENT_NAME=cluster-name
 export IMAGE_TAG=latest

--- a/tools/image-configure
+++ b/tools/image-configure
@@ -11,5 +11,4 @@ perl -pi -e "s/USE_FROZEN=[\d]/USE_FROZEN=$USE_FROZEN/g" setup-env
 
 perl -pi -e "s/PERSONAL_IMAGE=[\d]/PERSONAL_IMAGE=1/g" setup-env
 
-
 cat  setup-env


### PR DESCRIPTION
Updated Tike frozen specs for source code scanning.
Set default USE_CENTRAL_ECR=false in setup-env.template
Fix jwebbinar setup-notebooks, evidently whacked by accidental edit (in main).
Update jwebbinar frozen specs to satisfy safety scanning and pillow vulnerability.