### PR TITLE
Fix git-sync

### DIFF
--- a/deployments/common/image/common-scripts/git-sync
+++ b/deployments/common/image/common-scripts/git-sync
@@ -62,7 +62,7 @@ class GitSync(object):
 
         modified = []
         for f in files:
-            retcode = os.system('git diff --exit-code {}'.format(f))
+            retcode = os.system('git diff -w --exit-code {}'.format(f))
             if retcode != 0:
                 modified.append(f)
 

--- a/deployments/jwebbinar/image/environments/frozen/jdaviz-frozen.yml
+++ b/deployments/jwebbinar/image/environments/frozen/jdaviz-frozen.yml
@@ -12,7 +12,9 @@ dependencies:
   - backports.functools_lru_cache=1.6.4
   - bleach=3.3.0
   - blosc=1.21.0
+  - bqplot-image-gl=1.4.2
   - brotli=1.0.9
+  - brotli-bin=1.0.9
   - brotlipy=0.7.0
   - brunsli=0.1
   - bzip2=1.0.8
@@ -26,19 +28,20 @@ dependencies:
   - cryptography=3.4.7
   - cycler=0.10.0
   - cytoolz=0.11.0
+  - debugpy=1.3.0
   - defusedxml=0.7.1
   - entrypoints=0.3
   - freetype=2.10.4
-  - fsspec=2021.6.0
+  - fsspec=2021.6.1
   - giflib=5.2.1
   - idna=2.10
   - imagecodecs=2021.6.8
   - imageio=2.9.0
-  - importlib-metadata=4.5.0
+  - importlib-metadata=4.6.0
   - ipydatawidgets=4.2.0
-  - ipykernel=5.5.5
+  - ipykernel=6.0.1
   - ipympl=0.7.0
-  - ipython=7.24.1
+  - ipython=7.25.0
   - ipython_genutils=0.2.0
   - ipyvolume=0.6.0a8
   - ipyvue=1.5.0
@@ -57,10 +60,13 @@ dependencies:
   - kiwisolver=1.3.1
   - krb5=1.19.1
   - lcms2=2.12
-  - ld_impl_linux-64=2.35.1
+  - ld_impl_linux-64=2.36.1
   - lerc=2.2.1
   - libaec=1.0.5
   - libblas=3.9.0
+  - libbrotlicommon=1.0.9
+  - libbrotlidec=1.0.9
+  - libbrotlienc=1.0.9
   - libcblas=3.9.0
   - libcurl=7.77.0
   - libdeflate=1.7
@@ -86,7 +92,6 @@ dependencies:
   - matplotlib-inline=0.1.2
   - mistune=0.8.4
   - nbclient=0.5.3
-  - nbconvert=6.0.7
   - ncurses=6.2
   - nest-asyncio=1.5.1
   - networkx=2.5
@@ -94,11 +99,11 @@ dependencies:
   - openjpeg=2.4.0
   - openssl=1.1.1k
   - packaging=20.9
-  - pandoc=2.14.0.2
+  - pandoc=2.14.0.3
   - partd=1.2.0
   - pexpect=4.8.0
   - pickleshare=0.7.5
-  - pip=21.1.2
+  - pip=21.1.3
   - pooch=1.4.0
   - ptyprocess=0.7.0
   - pycparser=2.20
@@ -148,15 +153,14 @@ dependencies:
     - astropy-sphinx-theme==1.1
     - async-timeout==3.0.1
     - attrs==20.3.0
-    - awscli==1.19.98
+    - awscli==1.19.104
     - babel==2.9.1
     - black==21.6b0
     - bokeh==2.3.2
-    - boto3==1.17.98
-    - botocore==1.20.98
+    - boto3==1.17.104
+    - botocore==1.20.104
     - bottleneck==1.3.2
     - bqplot==0.12.27
-    - bqplot-image-gl==1.4.2
     - certifi==2020.12.5
     - ci-watson==0.5
     - click==7.1.2
@@ -176,7 +180,7 @@ dependencies:
     - freetype-py==2.2.0
     - glue-astronomy==0.1
     - glue-core==1.0.1
-    - glue-jupyter==0.6.1
+    - glue-jupyter==0.7
     - glue-vispy-viewers==1.0.2
     - gwcs==0.16.1
     - h5py==3.2.1
@@ -186,7 +190,7 @@ dependencies:
     - ipygoldenlayout==0.4.0
     - ipysplitpanes==0.2.0
     - ipywidgets-bokeh==1.0.2
-    - jdaviz==1.2.dev276+g2dbd8d0
+    - jdaviz==1.2.dev317+g9ce4a91
     - jinja2==2.11.3
     - jmespath==0.10.0
     - joblib==1.0.1
@@ -206,6 +210,7 @@ dependencies:
     - multidict==5.1.0
     - mypy-extensions==0.4.3
     - nbclassic==0.3.0
+    - nbconvert==6.0.7
     - nbformat==5.1.2
     - notebook==6.3.0
     - numpy==1.20.1
@@ -233,13 +238,13 @@ dependencies:
     - pyopengl==3.1.5
     - pytest==6.2.4
     - pytest-cov==2.12.1
-    - pytest-doctestplus==0.9.0
+    - pytest-doctestplus==0.10.0
     - pytest-openfiles==0.5.0
     - pyzmq==22.0.3
     - qtconsole==5.0.3
     - qtpy==1.9.0
     - radio-beam==0.3.3
-    - regex==2021.4.4
+    - regex==2021.7.1
     - regions==0.4
     - requests-mock==1.9.3
     - rsa==4.7.2
@@ -256,7 +261,7 @@ dependencies:
     - spherical-geometry==1.2.20
     - sphinx==3.5.4
     - sphinx-asdf==0.1.1
-    - sphinx-astropy==1.3
+    - sphinx-astropy==1.4
     - sphinx-automodapi==0.13
     - sphinx-bootstrap-theme==0.7.1
     - sphinx-gallery==0.9.0

--- a/deployments/jwebbinar/image/environments/frozen/jwebbinar-frozen.yml
+++ b/deployments/jwebbinar/image/environments/frozen/jwebbinar-frozen.yml
@@ -8,7 +8,7 @@ dependencies:
   - certifi=2021.5.30
   - fftw=3.3.9
   - freetds=1.1.15
-  - ld_impl_linux-64=2.35.1
+  - ld_impl_linux-64=2.36.1
   - libblas=3.9.0
   - libcblas=3.9.0
   - libedit=3.1.20191231
@@ -22,9 +22,9 @@ dependencies:
   - libopenblas=0.3.15
   - libstdcxx-ng=9.3.0
   - ncurses=6.2
-  - numpy=1.20.3
+  - numpy=1.21.0
   - openssl=1.1.1k
-  - pip=21.1.2
+  - pip=21.1.3
   - pyfftw=0.12.0
   - python=3.8.0
   - python_abi=3.8
@@ -40,26 +40,26 @@ dependencies:
     - aiohttp==3.7.4.post0
     - alabaster==0.7.12
     - ansiwrap==0.8.4
-    - anyio==3.2.0
+    - anyio==3.2.1
     - appdirs==1.4.4
     - argon2-cffi==20.1.0
     - asdf==2.8.1
     - astropy==4.2.1
     - astropy-sphinx-theme==1.1
-    - astroquery==0.4.3.dev6842
+    - astroquery==0.4.3.dev6862
     - astroscrappy==1.0.8
     - async-generator==1.10
     - async-timeout==3.0.1
     - attrs==21.2.0
-    - awscli==1.19.98
+    - awscli==1.19.104
     - babel==2.9.1
     - backcall==0.2.0
     - beautifulsoup4==4.9.3
     - black==21.6b0
     - bleach==3.3.0
     - bokeh==2.3.2
-    - boto3==1.17.98
-    - botocore==1.20.98
+    - boto3==1.17.104
+    - botocore==1.20.104
     - bottleneck==1.3.2
     - bqplot==0.12.27
     - bqplot-image-gl==1.4.2
@@ -74,6 +74,7 @@ dependencies:
     - cryptography==3.4.7
     - cycler==0.10.0
     - cython==0.29.23
+    - debugpy==1.3.0
     - decorator==4.4.2
     - defusedxml==0.7.1
     - dill==0.3.4
@@ -90,17 +91,18 @@ dependencies:
     - freetype-py==2.2.0
     - ginga==3.2.0
     - glue-core==1.0.1
-    - glue-jupyter==0.6.1
+    - glue-jupyter==0.7
     - glue-vispy-viewers==1.0.2
     - gwcs==0.16.1
     - h5py==3.3.0
     - healpy==1.15.0
+    - hsluv==5.0.2
     - html5lib==1.1
     - idna==2.10
     - imageio==2.9.0
     - imagesize==1.2.0
-    - importlib-metadata==4.5.0
-    - importlib-resources==5.1.4
+    - importlib-metadata==4.6.0
+    - importlib-resources==5.2.0
     - iniconfig==1.1.1
     - ipydatawidgets==4.2.0
     - ipyevents==0.8.2
@@ -128,7 +130,7 @@ dependencies:
     - jupyter-client==6.1.12
     - jupyter-core==4.7.1
     - jupyter-packaging==0.7.12
-    - jupyter-server==1.8.0
+    - jupyter-server==1.9.0
     - jupyter-server-proxy==3.0.2
     - jupyterlab==3.0.12
     - jupyterlab-pygments==0.1.2
@@ -154,7 +156,7 @@ dependencies:
     - mypy-extensions==0.4.3
     - nbclassic==0.3.1
     - nbclient==0.5.3
-    - nbconvert==6.0.7
+    - nbconvert==6.1.0
     - nbformat==5.1.3
     - nest-asyncio==1.5.1
     - networkx==2.5.1
@@ -163,7 +165,7 @@ dependencies:
     - openpyxl==3.0.7
     - packaging==20.9
     - pandas==1.2.5
-    - pandeia-engine==1.6
+    - pandeia-engine==1.6.1
     - pandocfilters==1.4.3
     - pandokia==2.3.0
     - papermill==2.3.3
@@ -173,7 +175,7 @@ dependencies:
     - pexpect==4.8.0
     - photutils==1.1.0
     - pickleshare==0.7.5
-    - pillow==8.2.0
+    - pillow==8.3.0
     - pipdeptree==2.0.0
     - pluggy==0.13.1
     - poppy==0.9.2
@@ -191,12 +193,12 @@ dependencies:
     - pygments==2.9.0
     - pyopengl==3.1.5
     - pyparsing==2.4.7
-    - pyrsistent==0.17.3
+    - pyrsistent==0.18.0
     - pysiaf==0.11.0
-    - pysynphot==1.0.0
+    - pysynphot==1.0.1
     - pytest==6.2.4
     - pytest-cov==2.12.1
-    - pytest-doctestplus==0.9.0
+    - pytest-doctestplus==0.10.0
     - pytest-openfiles==0.5.0
     - python-daemon==2.3.0
     - python-dateutil==2.8.1
@@ -206,14 +208,15 @@ dependencies:
     - pywavelets==1.1.1
     - pyyaml==5.4.1
     - pyzmq==22.1.0
-    - qtconsole==5.1.0
+    - qtconsole==5.1.1
     - qtpy==1.9.0
-    - regex==2021.4.4
+    - regex==2021.7.1
     - requests==2.25.1
     - requests-mock==1.9.3
+    - requests-unixsocket==0.2.0
     - rsa==4.7.2
     - s3transfer==0.4.2
-    - scikit-image==0.18.1
+    - scikit-image==0.18.2
     - scikit-learn==0.24.2
     - scipy==1.7.0
     - secretstorage==3.3.1
@@ -227,7 +230,7 @@ dependencies:
     - spherical-geometry==1.2.20
     - sphinx==3.5.4
     - sphinx-asdf==0.1.1
-    - sphinx-astropy==1.3
+    - sphinx-astropy==1.4
     - sphinx-automodapi==0.13
     - sphinx-bootstrap-theme==0.7.1
     - sphinx-gallery==0.9.0
@@ -245,8 +248,8 @@ dependencies:
     - stsci-rtd-theme==0.0.2
     - stsci-stimage==0.2.4
     - stsci-tools==3.6.0
-    - stsynphot==1.0.0
-    - synphot==1.0.1
+    - stsynphot==1.1.0
+    - synphot==1.1.0
     - tenacity==7.0.0
     - terminado==0.10.1
     - testpath==0.5.0
@@ -260,8 +263,8 @@ dependencies:
     - traittypes==0.2.1
     - tweakwcs==0.7.2
     - typing-extensions==3.10.0.0
-    - urllib3==1.26.5
-    - vispy==0.6.6
+    - urllib3==1.26.6
+    - vispy==0.7.0
     - wcwidth==0.2.5
     - webbpsf==0.9.1
     - webencodings==0.5.1


### PR DESCRIPTION
`git-sync` was creating backups of files that had no changes other than whitespace (between the repo and the clone in the image).

Adding `-w` to `git diff` in the script fixes this problem.