### PR TITLE
Jwebbinar saftey fix + misc

### DIFF
--- a/deployments/common/image/Dockerfile
+++ b/deployments/common/image/Dockerfile
@@ -146,6 +146,12 @@ COPY common-scripts/ /opt/common-scripts
 COPY common-env/ /opt/common-env
 RUN cat /opt/common-scripts/global_bashrc >> /etc/bash.bashrc
 
+# ------------------------------------------------------------------------
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && \
+    ./aws/install && \
+    rm -rf awscliv2
+
 # ----------------------------------------------------------------------
 # Common conda environments
 # USER ${NB_UID}

--- a/deployments/common/image/common-env/common.conda
+++ b/deployments/common/image/common-env/common.conda
@@ -1,0 +1,1 @@
+conda-tree

--- a/deployments/common/image/common-env/common.pip
+++ b/deployments/common/image/common-env/common.pip
@@ -2,6 +2,6 @@ papermill
 nbconvert
 ipykernel
 boto3
-awscli
 pyds9
 pipdeptree
+altair

--- a/deployments/jwebbinar/image/Dockerfile
+++ b/deployments/jwebbinar/image/Dockerfile
@@ -64,18 +64,15 @@ RUN /opt/common-scripts/env-create jwebbinar /opt/environments/jwebbinar/jwebbin
 RUN /opt/common-scripts/install-common jwebbinar
 RUN /opt/common-scripts/env-update jwebbinar /opt/environments/jwebbinar/jwebbinar.pip
 
-RUN /opt/common-scripts/install-common jwebbinar
-
 COPY --chown=${NB_UID}:${NB_GID} environments/jwebbinar/ /opt/environments/jwebbinar
 
 # ----------------------------------------------------------------------
 # Jdaviz
 COPY environments/jdaviz/jdaviz.yml /opt/environments/jdaviz/jdaviz.yml
 RUN /opt/common-scripts/env-create jdaviz /opt/environments/jdaviz/jdaviz.yml
+RUN /opt/common-scripts/install-common jdaviz
 COPY environments/jdaviz/jdaviz.pip /opt/environments/jdaviz/jdaviz.pip
 RUN /opt/common-scripts/env-update jdaviz /opt/environments/jdaviz/jdaviz.pip
-
-RUN /opt/common-scripts/install-common jdaviz
 
 COPY --chown=${NB_UID}:${NB_GID} environments/jdaviz/ /opt/environments/jdaviz
 

--- a/deployments/jwebbinar/image/Dockerfile.custom
+++ b/deployments/jwebbinar/image/Dockerfile.custom
@@ -64,18 +64,15 @@ RUN /opt/common-scripts/env-create jwebbinar /opt/environments/jwebbinar/jwebbin
 RUN /opt/common-scripts/install-common jwebbinar
 RUN /opt/common-scripts/env-update jwebbinar /opt/environments/jwebbinar/jwebbinar.pip
 
-RUN /opt/common-scripts/install-common jwebbinar
-
 COPY --chown=${NB_UID}:${NB_GID} environments/jwebbinar/ /opt/environments/jwebbinar
 
 # ----------------------------------------------------------------------
 # Jdaviz
 COPY environments/jdaviz/jdaviz.yml /opt/environments/jdaviz/jdaviz.yml
 RUN /opt/common-scripts/env-create jdaviz /opt/environments/jdaviz/jdaviz.yml
+RUN /opt/common-scripts/install-common jdaviz
 COPY environments/jdaviz/jdaviz.pip /opt/environments/jdaviz/jdaviz.pip
 RUN /opt/common-scripts/env-update jdaviz /opt/environments/jdaviz/jdaviz.pip
-
-RUN /opt/common-scripts/install-common jdaviz
 
 COPY --chown=${NB_UID}:${NB_GID} environments/jdaviz/ /opt/environments/jdaviz
 

--- a/deployments/jwebbinar/image/environments/frozen/jdaviz-frozen.yml
+++ b/deployments/jwebbinar/image/environments/frozen/jdaviz-frozen.yml
@@ -12,8 +12,10 @@ dependencies:
   - backports.functools_lru_cache=1.6.4
   - bleach=3.3.0
   - blosc=1.21.0
+  - bqplot=0.12.29
   - bqplot-image-gl=1.4.2
   - brotli=1.0.9
+  - brotli-bin=1.0.9
   - brotlipy=0.7.0
   - brunsli=0.1
   - bzip2=1.0.8
@@ -24,6 +26,9 @@ dependencies:
   - chardet=4.0.0
   - charls=2.2.0
   - cloudpickle=1.6.0
+  - conda=4.10.3
+  - conda-package-handling=1.7.3
+  - conda-tree=0.1.1
   - cryptography=3.4.7
   - cycler=0.10.0
   - cytoolz=0.11.0
@@ -38,7 +43,7 @@ dependencies:
   - imageio=2.9.0
   - importlib-metadata=4.6.0
   - ipydatawidgets=4.2.0
-  - ipykernel=6.0.0
+  - ipykernel=6.0.1
   - ipympl=0.7.0
   - ipython=7.25.0
   - ipython_genutils=0.2.0
@@ -63,6 +68,9 @@ dependencies:
   - lerc=2.2.1
   - libaec=1.0.5
   - libblas=3.9.0
+  - libbrotlicommon=1.0.9
+  - libbrotlidec=1.0.9
+  - libbrotlienc=1.0.9
   - libcblas=3.9.0
   - libcurl=7.77.0
   - libdeflate=1.7
@@ -95,13 +103,15 @@ dependencies:
   - openjpeg=2.4.0
   - openssl=1.1.1k
   - packaging=20.9
-  - pandoc=2.14.0.2
+  - pandoc=2.14.0.3
   - partd=1.2.0
   - pexpect=4.8.0
   - pickleshare=0.7.5
-  - pip=21.1.2
+  - pillow=8.3.0
+  - pip=21.1.3
   - pooch=1.4.0
   - ptyprocess=0.7.0
+  - pycosat=0.6.3
   - pycparser=2.20
   - pyopenssl=20.0.1
   - pyparsing=2.4.7
@@ -116,6 +126,7 @@ dependencies:
   - pyyaml=5.4.1
   - readline=8.1
   - requests=2.25.1
+  - ruamel_yaml=0.15.80
   - scikit-image=0.18.1
   - setuptools=49.6.0
   - snappy=1.1.8
@@ -123,6 +134,7 @@ dependencies:
   - tk=8.6.10
   - toolz=0.11.1
   - tornado=6.1
+  - tqdm=4.61.1
   - traitlets=5.0.5
   - traittypes=0.2.1
   - tzdata=2021a
@@ -140,6 +152,7 @@ dependencies:
   - pip:
     - aiohttp==3.7.4.post0
     - alabaster==0.7.12
+    - altair==4.1.0
     - ansiwrap==0.8.4
     - anyio==2.2.0
     - appnope==0.1.2
@@ -149,25 +162,22 @@ dependencies:
     - astropy-sphinx-theme==1.1
     - async-timeout==3.0.1
     - attrs==20.3.0
-    - awscli==1.19.98
     - babel==2.9.1
     - black==21.6b0
     - bokeh==2.3.2
-    - boto3==1.17.98
-    - botocore==1.20.98
+    - boto3==1.17.105
+    - botocore==1.20.105
     - bottleneck==1.3.2
-    - bqplot==0.12.27
     - certifi==2020.12.5
     - ci-watson==0.5
     - click==7.1.2
     - codecov==2.1.11
-    - colorama==0.4.3
     - coverage==5.5
     - crds==11.0.4
     - dask==2021.3.0
     - decorator==4.4.2
     - dill==0.3.3
-    - docutils==0.15.2
+    - docutils==0.16
     - drizzle==1.13.3
     - echo==0.5
     - fast-histogram==0.9
@@ -176,17 +186,18 @@ dependencies:
     - freetype-py==2.2.0
     - glue-astronomy==0.1
     - glue-core==1.0.1
-    - glue-jupyter==0.6.1
+    - glue-jupyter==0.7
     - glue-vispy-viewers==1.0.2
     - gwcs==0.16.1
     - h5py==3.2.1
+    - hsluv==5.0.2
     - imagesize==1.2.0
     - iniconfig==1.1.1
     - ipyevents==0.8.2
     - ipygoldenlayout==0.4.0
     - ipysplitpanes==0.2.0
     - ipywidgets-bokeh==1.0.2
-    - jdaviz==1.2.dev276+g2dbd8d0
+    - jdaviz==1.2.dev325+g98540d2
     - jinja2==2.11.3
     - jmespath==0.10.0
     - joblib==1.0.1
@@ -218,14 +229,12 @@ dependencies:
     - parso==0.8.1
     - pathspec==0.8.1
     - photutils==1.1.0
-    - pillow==8.1.2
     - pipdeptree==2.0.0
     - pluggy==0.13.1
     - prometheus-client==0.9.0
     - prompt-toolkit==3.0.18
     - psutil==5.8.0
     - py==1.10.0
-    - pyasn1==0.4.8
     - pycodestyle==2.7.0
     - pyds9==1.8.1
     - pyerfa==1.7.2
@@ -234,16 +243,16 @@ dependencies:
     - pyopengl==3.1.5
     - pytest==6.2.4
     - pytest-cov==2.12.1
-    - pytest-doctestplus==0.9.0
+    - pytest-doctestplus==0.10.0
     - pytest-openfiles==0.5.0
     - pyzmq==22.0.3
     - qtconsole==5.0.3
     - qtpy==1.9.0
     - radio-beam==0.3.3
-    - regex==2021.4.4
+    - regex==2021.7.1
     - regions==0.4
     - requests-mock==1.9.3
-    - rsa==4.7.2
+    - requests-unixsocket==0.2.0
     - s3transfer==0.4.2
     - scipy==1.6.1
     - semantic-version==2.8.5
@@ -278,12 +287,12 @@ dependencies:
     - textwrap3==0.9.2
     - tifffile==2021.3.17
     - toml==0.10.2
-    - tqdm==4.61.1
     - tweakwcs==0.7.2
     - typing-extensions==3.10.0.0
     - urllib3==1.26.4
     - vispy==0.6.6
     - voila==0.2.7
+    - websocket-client==1.1.0
     - xlrd==2.0.1
     - yarl==1.6.3
 prefix: /opt/conda/envs/jdaviz

--- a/deployments/jwebbinar/image/environments/frozen/jwebbinar-frozen.yml
+++ b/deployments/jwebbinar/image/environments/frozen/jwebbinar-frozen.yml
@@ -4,10 +4,19 @@ channels:
 dependencies:
   - _libgcc_mutex=0.1
   - _openmp_mutex=4.5
+  - brotlipy=0.7.0
   - ca-certificates=2021.5.30
   - certifi=2021.5.30
+  - cffi=1.14.4
+  - chardet=4.0.0
+  - conda=4.10.3
+  - conda-package-handling=1.7.3
+  - conda-tree=0.1.1
+  - cryptography=3.4.7
+  - decorator=5.0.9
   - fftw=3.3.9
   - freetds=1.1.15
+  - idna=2.10
   - ld_impl_linux-64=2.36.1
   - libblas=3.9.0
   - libcblas=3.9.0
@@ -22,63 +31,69 @@ dependencies:
   - libopenblas=0.3.15
   - libstdcxx-ng=9.3.0
   - ncurses=6.2
+  - networkx=2.5
   - numpy=1.21.0
   - openssl=1.1.1k
   - pip=21.1.3
+  - pycosat=0.6.3
+  - pycparser=2.20
   - pyfftw=0.12.0
+  - pyopenssl=20.0.1
+  - pysocks=1.7.1
   - python=3.8.0
   - python_abi=3.8
   - readline=8.1
+  - requests=2.25.1
+  - ruamel_yaml=0.15.80
   - setuptools=49.6.0
+  - six=1.16.0
   - sqlite=3.36.0
   - tk=8.6.10
+  - tqdm=4.61.1
   - unixodbc=2.3.9
+  - urllib3=1.26.6
   - wheel=0.36.2
   - xz=5.2.5
+  - yaml=0.2.5
   - zlib=1.2.11
   - pip:
     - aiohttp==3.7.4.post0
     - alabaster==0.7.12
+    - altair==4.1.0
     - ansiwrap==0.8.4
-    - anyio==3.2.0
+    - anyio==3.2.1
     - appdirs==1.4.4
     - argon2-cffi==20.1.0
     - asdf==2.8.1
     - astropy==4.2.1
     - astropy-sphinx-theme==1.1
-    - astroquery==0.4.3.dev6842
+    - astroquery==0.4.3.dev6862
     - astroscrappy==1.0.8
     - async-generator==1.10
     - async-timeout==3.0.1
     - attrs==21.2.0
-    - awscli==1.19.103
     - babel==2.9.1
     - backcall==0.2.0
     - beautifulsoup4==4.9.3
     - black==21.6b0
     - bleach==3.3.0
     - bokeh==2.3.2
-    - boto3==1.17.98
-    - botocore==1.20.98
+    - boto3==1.17.105
+    - botocore==1.20.105
     - bottleneck==1.3.2
     - bqplot==0.12.27
     - bqplot-image-gl==1.4.2
-    - cffi==1.14.5
-    - chardet==4.0.0
     - ci-watson==0.5
     - click==8.0.1
     - codecov==2.1.11
-    - colorama==0.4.3
     - coverage==5.5
     - crds==11.0.4
-    - cryptography==3.4.7
     - cycler==0.10.0
     - cython==0.29.23
     - debugpy==1.3.0
-    - decorator==4.4.2
     - defusedxml==0.7.1
     - dill==0.3.4
-    - docutils==0.15.2
+    - docutils==0.16
     - drizzle==1.13.3
     - dust-extinction==1.0
     - echo==0.5
@@ -91,13 +106,13 @@ dependencies:
     - freetype-py==2.2.0
     - ginga==3.2.0
     - glue-core==1.0.1
-    - glue-jupyter==0.6.1
+    - glue-jupyter==0.7
     - glue-vispy-viewers==1.0.2
     - gwcs==0.16.1
     - h5py==3.3.0
     - healpy==1.15.0
+    - hsluv==5.0.2
     - html5lib==1.1
-    - idna==2.10
     - imageio==2.9.0
     - imagesize==1.2.0
     - importlib-metadata==4.6.0
@@ -158,13 +173,12 @@ dependencies:
     - nbconvert==6.1.0
     - nbformat==5.1.3
     - nest-asyncio==1.5.1
-    - networkx==2.5.1
     - notebook==6.4.0
     - numpydoc==1.1.0
     - openpyxl==3.0.7
     - packaging==20.9
     - pandas==1.2.5
-    - pandeia-engine==1.6
+    - pandeia-engine==1.6.1
     - pandocfilters==1.4.3
     - pandokia==2.3.0
     - papermill==2.3.3
@@ -183,9 +197,7 @@ dependencies:
     - psutil==5.8.0
     - ptyprocess==0.7.0
     - py==1.10.0
-    - pyasn1==0.4.8
     - pycodestyle==2.7.0
-    - pycparser==2.20
     - pyds9==1.8.1
     - pyerfa==2.0.0
     - pyflakes==2.3.1
@@ -197,7 +209,7 @@ dependencies:
     - pysynphot==1.0.1
     - pytest==6.2.4
     - pytest-cov==2.12.1
-    - pytest-doctestplus==0.9.0
+    - pytest-doctestplus==0.10.0
     - pytest-openfiles==0.5.0
     - python-daemon==2.3.0
     - python-dateutil==2.8.1
@@ -209,11 +221,9 @@ dependencies:
     - pyzmq==22.1.0
     - qtconsole==5.1.1
     - qtpy==1.9.0
-    - regex==2021.4.4
-    - requests==2.25.1
+    - regex==2021.7.1
     - requests-mock==1.9.3
     - requests-unixsocket==0.2.0
-    - rsa==4.7.2
     - s3transfer==0.4.2
     - scikit-image==0.18.2
     - scikit-learn==0.24.2
@@ -222,7 +232,6 @@ dependencies:
     - semantic-version==2.8.5
     - send2trash==1.7.1
     - simpervisor==0.4
-    - six==1.16.0
     - sniffio==1.2.0
     - snowballstemmer==2.1.0
     - soupsieve==2.2.1
@@ -256,13 +265,12 @@ dependencies:
     - threadpoolctl==2.1.0
     - tifffile==2021.6.14
     - toml==0.10.2
+    - toolz==0.11.1
     - tornado==6.1
-    - tqdm==4.61.1
     - traitlets==5.0.5
     - traittypes==0.2.1
     - tweakwcs==0.7.2
     - typing-extensions==3.10.0.0
-    - urllib3==1.26.6
     - vispy==0.7.0
     - wcwidth==0.2.5
     - webbpsf==0.9.1

--- a/deployments/jwebbinar/image/environments/jdaviz/jdaviz.pip
+++ b/deployments/jwebbinar/image/environments/jdaviz/jdaviz.pip
@@ -54,7 +54,7 @@ pandocfilters==1.4.3
 parso==0.8.1
 pexpect==4.8.0
 pickleshare==0.7.5
-Pillow==8.1.2
+Pillow
 prometheus-client==0.9.0
 prompt-toolkit==3.0.18
 ptyprocess==0.7.0


### PR DESCRIPTION
Refactored jwebbinar: unpinned Pillow for safety scan vulnerability.
Dropped duplicate install-common for jwebbinar or jdaviz saving 4-5 min build time, storage unknown.
Re-ordered jwebbinar's install-common's so they happen before key environment
  functionality;  that may be backwards but at least they're consistent.
Added altair and conda-tree to common installs.  altair is an alternative plotting
  package to matplotlib.  conda-tree is a dependency debug tool for conda.
Switched to AWS cli v2.