### PR TITLE
Script for deleting ECR images that are failing security scans

### DIFF
--- a/deployments/roman/image/environments/frozen/cvt-frozen.yml
+++ b/deployments/roman/image/environments/frozen/cvt-frozen.yml
@@ -21,9 +21,11 @@ dependencies:
   - bleach=3.3.0
   - blinker=1.4
   - blosc=1.21.0
-  - bokeh=2.3.2
+  - bokeh=2.3.3
   - bottleneck=1.3.2
+  - bqplot-image-gl=1.4.2
   - brotli=1.0.9
+  - brotli-bin=1.0.9
   - brotlipy=0.7.0
   - brunsli=0.1
   - bzip2=1.0.8
@@ -33,20 +35,23 @@ dependencies:
   - cached_property=1.5.2
   - certifi=2021.5.30
   - certipy=0.1.3
-  - cffi=1.14.5
+  - cffi=1.14.6
   - cfitsio=3.470
   - chardet=4.0.0
   - charls=2.2.0
   - click=8.0.1
   - cloudpickle=1.6.0
+  - conda=4.10.3
   - conda-package-handling=1.7.3
+  - conda-tree=0.1.1
   - configurable-http-proxy=4.4.0
   - cryptography=3.4.7
   - cycler=0.10.0
-  - cython=0.29.23
+  - cython=0.29.24
   - cytoolz=0.11.0
   - dask=2021.6.2
   - dask-core=2021.6.2
+  - debugpy=1.3.0
   - decorator=4.4.2
   - defusedxml=0.7.1
   - dill=0.3.4
@@ -54,28 +59,28 @@ dependencies:
   - entrypoints=0.3
   - filelock=3.0.12
   - freetype=2.10.4
-  - fsspec=2021.6.1
+  - fsspec=2021.7.0
   - giflib=5.2.1
   - glob2=0.7
   - gmp=6.2.1
   - gmpy2=2.1.0b5
   - greenlet=1.1.0
-  - h5py=3.2.1
+  - h5py=3.3.0
   - hdf5=1.10.6
   - heapdict=1.0.1
   - icu=68.1
   - idna=2.10
   - imagecodecs=2021.6.8
   - imageio=2.9.0
-  - importlib-metadata=4.6.0
+  - importlib-metadata=4.6.1
   - ipydatawidgets=4.2.0
   - ipyevents=0.8.2
-  - ipykernel=5.5.5
+  - ipykernel=6.0.1
   - ipympl=0.7.0
   - ipython=7.25.0
   - ipython_genutils=0.2.0
   - ipyvue=1.5.0
-  - ipyvuetify=1.7.0
+  - ipyvuetify=1.8.0
   - ipywidgets=7.6.3
   - jbig=2.1
   - jedi=0.18.0
@@ -91,7 +96,7 @@ dependencies:
   - jupyterhub=1.4.1
   - jupyterhub-base=1.4.1
   - jupyterlab_pygments=0.1.2
-  - jupyterlab_server=2.6.0
+  - jupyterlab_server=2.6.1
   - jupyterlab_widgets=1.0.0
   - jxrlib=1.1
   - kiwisolver=1.3.1
@@ -102,6 +107,9 @@ dependencies:
   - libaec=1.0.5
   - libarchive=3.5.1
   - libblas=3.9.0
+  - libbrotlicommon=1.0.9
+  - libbrotlidec=1.0.9
+  - libbrotlienc=1.0.9
   - libcblas=3.9.0
   - libcurl=7.77.0
   - libdeflate=1.7
@@ -125,11 +133,11 @@ dependencies:
   - libssh2=1.9.0
   - libstdcxx-ng=9.3.0
   - libtiff=4.3.0
-  - libuv=1.41.0
+  - libuv=1.41.1
   - libwebp-base=1.2.0
   - libxml2=2.9.12
   - libzopfli=1.0.3
-  - llvm-openmp=11.1.0
+  - llvm-openmp=12.0.1
   - llvmlite=0.36.0
   - locket=0.2.0
   - lz4-c=1.9.3
@@ -150,7 +158,7 @@ dependencies:
   - nbformat=5.1.3
   - ncurses=6.2
   - nest-asyncio=1.5.1
-  - networkx=2.5.1
+  - networkx=2.6.1
   - nodejs=15.14.0
   - notebook=6.4.0
   - numba=0.53.1
@@ -161,9 +169,9 @@ dependencies:
   - openblas=0.3.15
   - openjpeg=2.4.0
   - openssl=1.1.1k
-  - packaging=20.9
+  - packaging=21.0
   - pamela=1.0.0
-  - pandas=1.2.5
+  - pandas=1.3.0
   - pandoc=2.14.0.3
   - pandocfilters=1.4.2
   - parso=0.8.2
@@ -172,9 +180,9 @@ dependencies:
   - patsy=0.5.1
   - pexpect=4.8.0
   - pickleshare=0.7.5
-  - pillow=8.2.0
+  - pillow=8.3.1
   - pip=21.1.3
-  - pkginfo=1.7.0
+  - pkginfo=1.7.1
   - pooch=1.4.0
   - prometheus_client=0.11.0
   - prompt-toolkit=3.0.19
@@ -211,9 +219,9 @@ dependencies:
   - ruamel.yaml=0.17.10
   - ruamel.yaml.clib=0.2.2
   - ruamel_yaml=0.15.80
-  - scikit-image=0.18.1
+  - scikit-image=0.18.2
   - scikit-learn=0.24.2
-  - scipy=1.6.3
+  - scipy=1.7.0
   - seaborn=0.11.1
   - seaborn-base=0.11.1
   - send2trash=1.7.1
@@ -230,12 +238,12 @@ dependencies:
   - tblib=1.7.0
   - terminado=0.10.1
   - testpath=0.5.0
-  - threadpoolctl=2.1.0
-  - tifffile=2021.6.14
+  - threadpoolctl=2.2.0
+  - tifffile=2021.7.2
   - tk=8.6.10
   - toolz=0.11.1
   - tornado=6.1
-  - tqdm=4.61.1
+  - tqdm=4.61.2
   - traitlets=5.0.5
   - traittypes=0.2.1
   - typing_extensions=3.10.0.0
@@ -253,7 +261,7 @@ dependencies:
   - zeromq=4.3.4
   - zfp=0.5.5
   - zict=2.0.0
-  - zipp=3.4.1
+  - zipp=3.5.0
   - zlib=1.2.11
   - zstd=1.5.0
   - pip:
@@ -263,28 +271,26 @@ dependencies:
     - astropy==4.2.1
     - astropy-sphinx-theme==1.1
     - async-timeout==3.0.1
-    - awscli==1.19.102
     - black==21.6b0
-    - boto3==1.17.102
-    - botocore==1.20.102
+    - boto3==1.17.111
+    - botocore==1.20.111
     - bqplot==0.12.27
-    - bqplot-image-gl==1.4.2
     - ci-watson==0.5
     - codecov==2.1.11
-    - colorama==0.4.3
     - coverage==5.5
-    - docutils==0.15.2
+    - docutils==0.16
     - echo==0.5
     - fast-histogram==0.9
     - flake8==3.9.2
     - freetype-py==2.2.0
     - glue-core==1.0.1
-    - glue-jupyter==0.2.2
+    - glue-jupyter==0.7
     - glue-vispy-viewers==1.0.2
+    - hsluv==5.0.2
     - imagesize==1.2.0
     - iniconfig==1.1.1
-    - ipygoldenlayout==0.4.0
-    - ipysplitpanes==0.2.0
+    - ipygoldenlayout==0.3.0
+    - ipysplitpanes==0.1.0
     - ipyvolume==0.5.2
     - ipywebrtc==0.6.0
     - ipywidgets-bokeh==1.0.2
@@ -292,7 +298,7 @@ dependencies:
     - jupyter-bokeh==3.0.2
     - jupyter-desktop-server==0.1.3
     - jupyter-packaging==0.7.12
-    - jupyter-server-proxy==3.0.2
+    - jupyter-server-proxy==3.1.0
     - jupyterlab==3.0.12
     - mccabe==0.6.1
     - mpl-scatter-density==0.7
@@ -305,7 +311,6 @@ dependencies:
     - pipdeptree==2.0.0
     - pluggy==0.13.1
     - py==1.10.0
-    - pyasn1==0.4.8
     - pycodestyle==2.7.0
     - pyds9==1.8.1
     - pyerfa==2.0.0
@@ -313,14 +318,13 @@ dependencies:
     - pyopengl==3.1.5
     - pytest==6.2.4
     - pytest-cov==2.12.1
-    - pytest-doctestplus==0.9.0
+    - pytest-doctestplus==0.10.0
     - pytest-openfiles==0.5.0
     - pythreejs==2.3.0
     - qtconsole==5.1.1
     - qtpy==1.9.0
-    - regex==2021.4.4
+    - regex==2021.7.6
     - requests-mock==1.9.3
-    - rsa==4.7.2
     - s3transfer==0.4.2
     - simpervisor==0.4
     - snowballstemmer==2.1.0
@@ -338,9 +342,9 @@ dependencies:
     - sphinxcontrib-qthelp==1.0.3
     - sphinxcontrib-serializinghtml==1.1.5
     - stsci-rtd-theme==0.0.2
-    - tenacity==7.0.0
+    - tenacity==8.0.1
     - textwrap3==0.9.2
     - toml==0.10.2
-    - vispy==0.6.6
+    - vispy==0.7.1
     - yarl==1.6.3
 prefix: /opt/conda/envs/cvt

--- a/deployments/roman/image/environments/frozen/roman-cal-frozen.yml
+++ b/deployments/roman/image/environments/frozen/roman-cal-frozen.yml
@@ -4,8 +4,15 @@ channels:
 dependencies:
   - _libgcc_mutex=0.1
   - _openmp_mutex=4.5
+  - brotlipy=0.7.0
   - ca-certificates=2021.5.30
   - certifi=2021.5.30
+  - cffi=1.14.6
+  - chardet=4.0.0
+  - conda=4.10.3
+  - conda-package-handling=1.7.3
+  - conda-tree=0.1.1
+  - cryptography=3.4.7
   - fftw=3.3.9
   - freetds=1.1.15
   - ld_impl_linux-64=2.36.1
@@ -25,20 +32,30 @@ dependencies:
   - numpy=1.21.0
   - openssl=1.1.1k
   - pip=21.1.3
+  - pycosat=0.6.3
+  - pycparser=2.20
   - pyfftw=0.12.0
+  - pyopenssl=20.0.1
+  - pysocks=1.7.1
   - python=3.8.10
   - python_abi=3.8
   - readline=8.1
+  - ruamel_yaml=0.15.80
   - setuptools=49.6.0
+  - six=1.16.0
   - sqlite=3.36.0
   - tk=8.6.10
+  - tqdm=4.61.2
   - unixodbc=2.3.9
+  - urllib3=1.26.6
   - wheel=0.36.2
   - xz=5.2.5
+  - yaml=0.2.5
   - zlib=1.2.11
   - pip:
     - aiohttp==3.7.4.post0
     - alabaster==0.7.12
+    - altair==4.1.0
     - ansiwrap==0.8.4
     - anyio==3.2.1
     - appdirs==1.4.4
@@ -47,40 +64,36 @@ dependencies:
     - asteval==0.9.25
     - astropy==4.2.1
     - astropy-sphinx-theme==1.1
-    - astroquery==0.4.2
+    - astroquery==0.4.3
     - astroscrappy==1.0.8
     - async-generator==1.10
     - async-timeout==3.0.1
     - attrs==21.2.0
-    - awscli==1.19.102
     - babel==2.9.1
     - backcall==0.2.0
     - beautifulsoup4==4.9.3
     - black==21.6b0
     - bleach==3.3.0
-    - bokeh==2.3.2
-    - boto3==1.17.102
-    - botocore==1.20.102
+    - bokeh==2.3.3
+    - boto3==1.17.111
+    - botocore==1.20.111
     - bottleneck==1.3.2
     - bqplot==0.12.27
     - bqplot-image-gl==1.4.2
-    - cffi==1.14.5
-    - chardet==4.0.0
+    - charset-normalizer==2.0.1
     - ci-watson==0.5
     - click==8.0.1
     - codecov==2.1.11
-    - colorama==0.4.3
     - coverage==5.5
     - crds==11.0.4
-    - cryptography==3.4.7
     - cubeviz==0.3.1
     - cycler==0.10.0
-    - cython==0.29.23
+    - cython==0.29.24
     - debugpy==1.3.0
     - decorator==4.4.2
     - defusedxml==0.7.1
     - dill==0.3.4
-    - docutils==0.15.2
+    - docutils==0.16
     - drizzle==1.13.3
     - dust-extinction==1.0
     - echo==0.5
@@ -93,38 +106,39 @@ dependencies:
     - freetype-py==2.2.0
     - ginga==3.2.0
     - glue-core==1.0.1
-    - glue-jupyter==0.2.2
+    - glue-jupyter==0.7
     - glue-vispy-viewers==1.0.2
     - gwcs==0.16.1
     - h5py==3.3.0
     - healpy==1.15.0
+    - hsluv==5.0.2
     - html5lib==1.1
-    - idna==2.10
+    - idna==3.2
     - imageio==2.9.0
     - imagesize==1.2.0
-    - importlib-metadata==4.6.0
+    - importlib-metadata==4.6.1
     - importlib-resources==5.2.0
     - iniconfig==1.1.1
     - ipydatawidgets==4.2.0
     - ipyevents==0.8.2
     - ipygoldenlayout==0.4.0
-    - ipykernel==6.0.0
+    - ipykernel==6.0.1
     - ipympl==0.7.0
     - ipysplitpanes==0.2.0
     - ipython==7.25.0
     - ipython-genutils==0.2.0
     - ipyvolume==0.5.2
     - ipyvue==1.5.0
-    - ipyvuetify==1.7.0
+    - ipyvuetify==1.8.0
     - ipywebrtc==0.6.0
     - ipywidgets==7.6.3
     - ipywidgets-bokeh==1.0.2
     - jedi==0.18.0
-    - jeepney==0.6.0
+    - jeepney==0.7.0
     - jinja2==3.0.1
     - jmespath==0.10.0
     - joblib==1.0.1
-    - jplephem==2.15
+    - jplephem==2.16
     - json5==0.9.6
     - jsonschema==3.2.0
     - jupyter-bokeh==3.0.2
@@ -132,10 +146,10 @@ dependencies:
     - jupyter-core==4.7.1
     - jupyter-packaging==0.7.12
     - jupyter-server==1.9.0
-    - jupyter-server-proxy==3.0.2
+    - jupyter-server-proxy==3.1.0
     - jupyterlab==3.0.12
     - jupyterlab-pygments==0.1.2
-    - jupyterlab-server==2.6.0
+    - jupyterlab-server==2.6.1
     - jupyterlab-widgets==1.0.0
     - jwst==1.1.0
     - jwst-backgrounds==1.1.2
@@ -164,8 +178,8 @@ dependencies:
     - notebook==6.4.0
     - numpydoc==1.1.0
     - openpyxl==3.0.7
-    - packaging==20.9
-    - pandas==1.2.5
+    - packaging==21.0
+    - pandas==1.3.0
     - pandeia-engine==1.6.1
     - pandocfilters==1.4.3
     - pandokia==2.3.0
@@ -176,7 +190,7 @@ dependencies:
     - pexpect==4.8.0
     - photutils==1.1.0
     - pickleshare==0.7.5
-    - pillow==8.2.0
+    - pillow==8.3.1
     - pipdeptree==2.0.0
     - pluggy==0.13.1
     - poppy==0.9.2
@@ -185,9 +199,7 @@ dependencies:
     - psutil==5.8.0
     - ptyprocess==0.7.0
     - py==1.10.0
-    - pyasn1==0.4.8
     - pycodestyle==2.7.0
-    - pycparser==2.20
     - pyds9==1.8.1
     - pyerfa==2.0.0
     - pyflakes==2.3.1
@@ -196,16 +208,16 @@ dependencies:
     - pyparsing==2.4.7
     - pyqt5==5.11.3
     - pyqt5-sip==4.19.19
-    - pyqtgraph==0.12.1
+    - pyqtgraph==0.12.2
     - pyrsistent==0.18.0
     - pysiaf==0.11.0
     - pysynphot==1.0.1
     - pytest==6.2.4
     - pytest-cov==2.12.1
-    - pytest-doctestplus==0.9.0
+    - pytest-doctestplus==0.10.0
     - pytest-openfiles==0.5.0
     - python-daemon==2.3.0
-    - python-dateutil==2.8.1
+    - python-dateutil==2.8.2
     - pythreejs==2.3.0
     - pytz==2021.1
     - pyvo==1.1
@@ -216,12 +228,11 @@ dependencies:
     - qtconsole==5.1.1
     - qtpy==1.9.0
     - radio-beam==0.3.3
-    - regex==2021.4.4
-    - requests==2.25.1
+    - regex==2021.7.6
+    - requests==2.26.0
     - requests-mock==1.9.3
     - requests-unixsocket==0.2.0
     - romancal==0.2.0
-    - rsa==4.7.2
     - s3transfer==0.4.2
     - scikit-image==0.18.2
     - scikit-learn==0.24.2
@@ -230,7 +241,6 @@ dependencies:
     - semantic-version==2.8.5
     - send2trash==1.7.1
     - simpervisor==0.4
-    - six==1.16.0
     - sniffio==1.2.0
     - snowballstemmer==2.1.0
     - soupsieve==2.2.1
@@ -260,21 +270,20 @@ dependencies:
     - stsci-tools==3.6.0
     - stsynphot==1.1.0
     - synphot==1.1.0
-    - tenacity==7.0.0
+    - tenacity==8.0.1
     - terminado==0.10.1
     - testpath==0.5.0
     - textwrap3==0.9.2
-    - threadpoolctl==2.1.0
-    - tifffile==2021.6.14
+    - threadpoolctl==2.2.0
+    - tifffile==2021.7.2
     - toml==0.10.2
+    - toolz==0.11.1
     - tornado==6.1
-    - tqdm==4.61.1
     - traitlets==5.0.5
     - traittypes==0.2.1
     - tweakwcs==0.7.2
     - typing-extensions==3.10.0.0
-    - urllib3==1.26.6
-    - vispy==0.6.6
+    - vispy==0.7.1
     - wcwidth==0.2.5
     - webbpsf==0.9.1
     - webencodings==0.5.1
@@ -282,5 +291,5 @@ dependencies:
     - widgetsnbextension==3.5.1
     - xlrd==2.0.1
     - yarl==1.6.3
-    - zipp==3.4.1
+    - zipp==3.5.0
 prefix: /opt/conda/envs/roman-cal

--- a/derived-env
+++ b/derived-env
@@ -4,16 +4,18 @@
 # automatically sourced into setup-env
 
 # Octarine AWS JupyterHub setup
-export ACCOUNT=${ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com
-export ECR_ACCOUNT=${CENTRAL_ECR_ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com
+#export ACCOUNT=${ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com
+#export ECR_ACCOUNT=${CENTRAL_ECR_ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com
 
 if [ "$USE_CENTRAL_ECR" = true ]
 then
-    export ECR_ACCOUNT_TO_USE=$ECR_ACCOUNT
+    export ECR_REGISTRY=${CENTRAL_ECR_ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com
     export IMAGE_REPO=${DEPLOYMENT_NAME}
+    export ECR_ACCOUNT_TO_USE=${CENTRAL_ECR_ACCOUNT_ID}
 else
-    export ECR_ACCOUNT_TO_USE=$ACCOUNT
+    export ECR_REGISTRY=${CENTRAL_ECR_ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com
     export IMAGE_REPO=${DEPLOYMENT_NAME}-user-image
+    export ECR_ACCOUNT_TO_USE=${ACCOUNT_ID}
 fi
 
 export JUPYTERHUB_DIR=`pwd`

--- a/derived-env
+++ b/derived-env
@@ -7,13 +7,13 @@
 #export ACCOUNT=${ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com
 #export ECR_ACCOUNT=${CENTRAL_ECR_ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com
 
-if [ "$USE_CENTRAL_ECR" = true ]
+if [ "$USE_CENTRAL_ECR" == "true" ]
 then
     export ECR_REGISTRY=${CENTRAL_ECR_ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com
     export IMAGE_REPO=${DEPLOYMENT_NAME}
     export ECR_ACCOUNT_TO_USE=${CENTRAL_ECR_ACCOUNT_ID}
 else
-    export ECR_REGISTRY=${CENTRAL_ECR_ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com
+    export ECR_REGISTRY=${ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com
     export IMAGE_REPO=${DEPLOYMENT_NAME}-user-image
     export ECR_ACCOUNT_TO_USE=${ACCOUNT_ID}
 fi
@@ -28,8 +28,8 @@ export COMMON_DIR=`pwd`/deployments/common/image
 export IMAGE_DIR=`pwd`/deployments/${DEPLOYMENT_NAME}/image
 
 if [[ "${PERSONAL_IMAGE}" == "0" ]]; then
-    export COMMON_ID=${ECR_ACCOUNT_TO_USE}/${COMMON_REPO}:${COMMON_TAG}
-    export IMAGE_ID=${ECR_ACCOUNT_TO_USE}/${IMAGE_REPO}:${IMAGE_TAG}
+    export COMMON_ID=${ECR_REGISTRY}/${COMMON_REPO}:${COMMON_TAG}
+    export IMAGE_ID=${ECR_REGISTRY}/${IMAGE_REPO}:${IMAGE_TAG}
 else
     export COMMON_ID=${COMMON_REPO}:${COMMON_TAG}
     export IMAGE_ID=${IMAGE_REPO}:${IMAGE_TAG}

--- a/setup-env.template
+++ b/setup-env.template
@@ -8,7 +8,7 @@
 
 export ACCOUNT_ID=12345678
 export CENTRAL_ECR_ACCOUNT_ID=12345678
-export USE_CENTERAL_ECR=false
+export USE_CENTRAL_ECR=false
 export ADMIN_ROLENAME=aws-admin-role
 export DEPLOYMENT_NAME=cluster-name
 export IMAGE_TAG=latest

--- a/tools/clean-ecr
+++ b/tools/clean-ecr
@@ -25,52 +25,28 @@ IMAGE_UBUNTU_NAME = os.environ.get('IMAGE_UBUNTU_NAME')
 
 CANDIDATES_FOR_DELETION = []
 
-DELETE_LEVELS = {
-    "CRITICAL" : ["CRITICAL"],
-    "HIGH": ["CRITICAL", "HIGH"],
-    "MEDIUM" : ["CRITICAL", "HIGH", "MEDIUM"],
-    "LOW" : ["CRITICAL", "HIGH", "MEDIUM", "LOW"],
-    "INFORMATIONAL" : ["CRITICAL", "HIGH", "MEDIUM", "LOW", "INFORMATIONAL"],
-    "ALL" : ["CRITICAL", "HIGH", "MEDIUM", "LOW", "INFORMATIONAL"],
-}
-
 
 class Image(object):
 
     def __init__(self, digest):
         self.digest = digest
         self.insecure = True
-        self.can_delete = False
         self.to_delete = False
 
     def scan(self, os_version, min_severity):
-        scan_output = None
         try:
             proc = subprocess.Popen(
                 f'image-scan-report {os_version} {min_severity} --image-digest {self.digest}'.split(),
                 stdout=subprocess.PIPE, stderr=subprocess.PIPE
             )
             scan_output, err = proc.communicate()
-            if proc.returncode == 0:
+            if 'overall_status: OK' in str(scan_output):
                 self.insecure = False
+                print(f'[OK] {self.digest}')
+            else:
+                print(f'Insecure image detected: {self.digest}')
         except Exception as e:
             raise e
-
-        if self.insecure:
-            print()
-            # THIS IS EMPTY
-            print(scan_output)
-            print()
-
-            fail_levels = DELETE_LEVELS[min_severity]
-            for l in fail_levels:
-                if l in str(scan_output):
-                    self.can_delete = True
-                    print(f'Insecure image detected: {self.digest}')
-
-
-
-
 
     def delete(self):
         subprocess.check_output(f"""
@@ -115,7 +91,7 @@ def main(args):
         img.scan(args.os_version, args.min_severity)
 
     # determine which images should be deleted
-    for img in [i for i in CANDIDATES_FOR_DELETION if i.can_delete]:
+    for img in [i for i in CANDIDATES_FOR_DELETION if i.insecure]:
         if args.delete_all:
             for img in CANDIDATES_FOR_DELETION:
                 img.to_delete = True

--- a/tools/clean-ecr
+++ b/tools/clean-ecr
@@ -75,7 +75,7 @@ def get_image_digests():
     digests = json.loads(untagged_images)['imageIds']
     return [i['imageDigest'] for i in digests]
 
-def main(delete_all, os_version, min_severity):
+def main(args):
     # find candidates for deletion (all untagged images in a repo)
     for d in get_image_digests():
         candidates_for_deletion.append(Image(d))
@@ -116,4 +116,4 @@ if __name__ == '__main__':
     )
     args = parser.parse_args()
 
-    main(delete_all, os_version, min_severity)
+    main(args)

--- a/tools/clean-ecr
+++ b/tools/clean-ecr
@@ -23,7 +23,16 @@ ECR_ACCOUNT_TO_USE = os.environ.get('ECR_ACCOUNT_TO_USE')
 IMAGE_REPO = os.environ.get('IMAGE_REPO')
 IMAGE_UBUNTU_NAME = os.environ.get('IMAGE_UBUNTU_NAME')
 
-candidates_for_deletion = []
+CANDIDATES_FOR_DELETION = []
+
+DELETE_LEVELS = {
+    "CRITICAL" : ["CRITICAL"],
+    "HIGH": ["CRITICAL", "HIGH"],
+    "MEDIUM" : ["CRITICAL", "HIGH", "MEDIUM"],
+    "LOW" : ["CRITICAL", "HIGH", "MEDIUM", "LOW"],
+    "INFORMATIONAL" : ["CRITICAL", "HIGH", "MEDIUM", "LOW", "INFORMATIONAL"],
+    "ALL" : ["CRITICAL", "HIGH", "MEDIUM", "LOW", "INFORMATIONAL"],
+}
 
 
 class Image(object):
@@ -32,6 +41,7 @@ class Image(object):
         self.digest = digest
         self.insecure = False
         self.to_delete = False
+        self.highest_severity = None
 
     def scan(self, os_version, min_severity):
         try:
@@ -78,22 +88,23 @@ def get_image_digests():
 def main(args):
     # find candidates for deletion (all untagged images in a repo)
     for d in get_image_digests():
-        candidates_for_deletion.append(Image(d))
+        CANDIDATES_FOR_DELETION.append(Image(d))
 
     # scan each image for vulnerabilities
-    for img in candidates_for_deletion:
+    for img in CANDIDATES_FOR_DELETION:
         img.scan(args.os_version, args.min_severity)
 
     # determine which images should be deleted
-    for img in candidates_for_deletion:
+    fail_levels = DELETE_LEVELS[min_severity]
+    for img in CANDIDATES_FOR_DELETION if img.highest_severity in fail_levels:
         if args.delete_all:
-            for img in candidates_for_deletion:
+            for img in CANDIDATES_FOR_DELETION:
                 img.to_delete = True
         else:
             prompt_for_deletion(img)
 
     # delete images
-    for img in candidates_for_deletion:
+    for img in CANDIDATES_FOR_DELETION:
         if img.to_delete:
             img.delete()
 

--- a/tools/clean-ecr
+++ b/tools/clean-ecr
@@ -1,16 +1,52 @@
 #! /usr/bin/env python
 
 import os
+import sys
 import subprocess
 import argparse
 import json
 
-
 admin_arn = os.environ.get('ADMIN_ARN')
-#env = os.environ.get('ENVIRONMENT')
 ecr_account_to_use = os.environ.get('ECR_ACCOUNT_TO_USE')
 image_repo = os.environ.get('IMAGE_REPO')
-#deployment_name = os.environ.get('DEPLOYMENT_NAME')
+
+
+candidates_for_deletion = []
+
+# TODO: add proper logging with levels
+
+class Image(object):
+
+    def __init__(self, digest):
+        self.digest = digest
+        self.insecure = False
+        self.delete = False
+
+    def scan(self):
+        try:
+            subprocess.check_output(f'image-scan-report Focal HIGH --image-digest {self.digest}'.split())
+        except subprocess.CalledProcessError:
+            self.insecure = True
+            print(f'Insecure image detected: {self.digest}')
+        except Exception as e:
+            raise e
+
+    def delete(self):
+        pass
+
+
+def prompt_for_deletion(img):
+    valid_inputs = {'y': True,'n': False}
+    prompt = f'Delete vulnerable image with digest {img.digest}? [y/N]'
+
+    while True:
+        sys.stdout.write(prompt)
+        response = input().lower()
+        if response in valid_inputs:
+            img.delete = valid_inputs[response]
+            break
+        else:
+            continue
 
 
 def get_image_digests():
@@ -24,16 +60,10 @@ def get_image_digests():
     return [i['imageDigest'] for i in digests]
 
 
-def main(delete_all):
-    digests = get_image_digests()
-    print(digests)
-
-
-
-
 
 
 if __name__ == '__main__':
+    # TODO: make Focal and HIGH optional args with defaults
     parser = argparse.ArgumentParser(
         description='Find and delete images in ECR that are failing security scans and are untagged'
     )
@@ -42,4 +72,49 @@ if __name__ == '__main__':
         help='don\'t prompt whether to delete each image, just delete all eligible')
     args = parser.parse_args()
 
-    main(args.delete_all)
+    # find candidates for deletion (all untagged images in a repo)
+    for d in get_image_digests():
+        candidates_for_deletion.append(Image(d))
+
+    # scan each image for vulnerabilities
+    for img in candidates_for_deletion:
+        img.scan()
+
+    for img in candidates_for_deletion:
+        if args.delete_all:
+            for img in candidates_for_deletion:
+                img.delete = True
+            #img.delete()
+            print('skipping "delete_all" for now...')
+        else:
+            prompt_for_deletion(img)
+
+    for img in candidates_for_deletion:
+        print(img.digest)
+        print(img.insecure)
+        print(img.delete)
+        print()
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/tools/clean-ecr
+++ b/tools/clean-ecr
@@ -101,8 +101,7 @@ def main(args):
     # delete images
     for img in CANDIDATES_FOR_DELETION:
         if img.to_delete:
-            pass
-            #img.delete()
+            img.delete()
 
 
 if __name__ == '__main__':

--- a/tools/clean-ecr
+++ b/tools/clean-ecr
@@ -10,21 +10,19 @@ admin_arn = os.environ.get('ADMIN_ARN')
 ecr_account_to_use = os.environ.get('ECR_ACCOUNT_TO_USE')
 image_repo = os.environ.get('IMAGE_REPO')
 
-
 candidates_for_deletion = []
 
-# TODO: add proper logging with levels
 
 class Image(object):
 
     def __init__(self, digest):
         self.digest = digest
         self.insecure = False
-        self.delete = False
+        self.to_delete = False
 
-    def scan(self):
+    def scan(self, os_version, min_severity):
         try:
-            subprocess.check_output(f'image-scan-report Focal HIGH --image-digest {self.digest}'.split())
+            subprocess.check_output(f'image-scan-report {os_version} {min_severity} --image-digest {self.digest}'.split())
         except subprocess.CalledProcessError:
             self.insecure = True
             print(f'Insecure image detected: {self.digest}')
@@ -32,8 +30,13 @@ class Image(object):
             raise e
 
     def delete(self):
-        pass
-
+        subprocess.check_output(f"""
+            awsudo -d 3600 {admin_arn} aws ecr batch-delete-image
+            --registry-id {ecr_account_to_use}
+            --repository-name {image_repo}
+            --image-ids imageDigest={self.digest}""".split()
+        )
+        print(f'Deleted image with digest: {self.digest}')
 
 def prompt_for_deletion(img):
     valid_inputs = {'y': True,'n': False}
@@ -43,7 +46,7 @@ def prompt_for_deletion(img):
         sys.stdout.write(prompt)
         response = input().lower()
         if response in valid_inputs:
-            img.delete = valid_inputs[response]
+            img.to_delete = valid_inputs[response]
             break
         else:
             continue
@@ -60,16 +63,22 @@ def get_image_digests():
     return [i['imageDigest'] for i in digests]
 
 
-
-
 if __name__ == '__main__':
-    # TODO: make Focal and HIGH optional args with defaults
     parser = argparse.ArgumentParser(
         description='Find and delete images in ECR that are failing security scans and are untagged'
     )
     parser.add_argument(
         '--all', dest='delete_all', action='store_true', default=False,
-        help='don\'t prompt whether to delete each image, just delete all eligible')
+        help='don\'t prompt whether to delete each image, just delete all untagged insecure images'
+    )
+    parser.add_argument(
+        '--os-version', dest='os_version', action='store', default='Focal',
+        help='Ubuntu version substring (default is "Focal")'
+    )
+    parser.add_argument(
+        '--min-severity-level', dest='min_severity', action='store', default='HIGH',
+        help='minimum severity level of vulnerabilities (default is "HIGH")'
+    )
     args = parser.parse_args()
 
     # find candidates for deletion (all untagged images in a repo)
@@ -78,43 +87,16 @@ if __name__ == '__main__':
 
     # scan each image for vulnerabilities
     for img in candidates_for_deletion:
-        img.scan()
+        img.scan(args.os_version, args.min_severity)
 
     for img in candidates_for_deletion:
         if args.delete_all:
             for img in candidates_for_deletion:
-                img.delete = True
-            #img.delete()
-            print('skipping "delete_all" for now...')
+                img.to_delete = True
         else:
             prompt_for_deletion(img)
 
+    # delete images
     for img in candidates_for_deletion:
-        print(img.digest)
-        print(img.insecure)
-        print(img.delete)
-        print()
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+        if img.to_delete:
+            img.delete()

--- a/tools/clean-ecr
+++ b/tools/clean-ecr
@@ -37,20 +37,35 @@ DELETE_LEVELS = {
 
 class Image(object):
 
-    def __init__(self, digest):
+    def __init__(self, digest, min_severity):
         self.digest = digest
+        self.min_severity = min_severity
         self.insecure = False
+        self.can_delete = False
         self.to_delete = False
-        self.highest_severity = None
+        self.highest_severity_found = None
 
     def scan(self, os_version, min_severity):
+        scan_output = '/tmp/scan-report.out'
         try:
-            subprocess.check_output(f'image-scan-report {os_version} {min_severity} --image-digest {self.digest}'.split())
+            scan_output = subprocess.check_output(f'image-scan-report {os_version} {min_severity} --image-digest {self.digest} > {scan_output}'.split())
         except subprocess.CalledProcessError:
             self.insecure = True
             print(f'Insecure image detected: {self.digest}')
         except Exception as e:
             raise e
+
+        if self.insecure:
+            scan_results = None
+            with open(scan_output) as f:
+                scan_results = f.read()
+            os.remove(scan_output)
+            print(scan_results)
+
+            fail_levels = DELETE_LEVELS[self.min_severity]
+            for l in fail_levels:
+                if l in scan_results:
+                    selt.can_delete = True
 
     def delete(self):
         subprocess.check_output(f"""
@@ -88,15 +103,14 @@ def get_image_digests():
 def main(args):
     # find candidates for deletion (all untagged images in a repo)
     for d in get_image_digests():
-        CANDIDATES_FOR_DELETION.append(Image(d))
+        CANDIDATES_FOR_DELETION.append(Image(d, min_severity))
 
     # scan each image for vulnerabilities
     for img in CANDIDATES_FOR_DELETION:
         img.scan(args.os_version, args.min_severity)
 
     # determine which images should be deleted
-    fail_levels = DELETE_LEVELS[min_severity]
-    for img in CANDIDATES_FOR_DELETION if img.highest_severity in fail_levels:
+    for img in [i for i in CANDIDATES_FOR_DELETION if i.can_delete]:
         if args.delete_all:
             for img in CANDIDATES_FOR_DELETION:
                 img.to_delete = True

--- a/tools/clean-ecr
+++ b/tools/clean-ecr
@@ -6,6 +6,18 @@ import subprocess
 import argparse
 import json
 
+"""
+This tool scans an ECR repository to find images with vulnerabilities.
+Images that are tagged are ignored.  All untagged images that are found to have
+vulnerabilities are considered to be candidates for deletion.
+
+Interactive and automated actions are both supported.  By default, this tool
+will ask you to confirm deletion of each image that has been found to be
+insecure.
+
+Run "clean-ecr --help" for usage information.
+"""
+
 admin_arn = os.environ.get('ADMIN_ARN')
 ecr_account_to_use = os.environ.get('ECR_ACCOUNT_TO_USE')
 image_repo = os.environ.get('IMAGE_REPO')
@@ -38,9 +50,10 @@ class Image(object):
         )
         print(f'Deleted image with digest: {self.digest}')
 
+
 def prompt_for_deletion(img):
     valid_inputs = {'y': True,'n': False}
-    prompt = f'Delete vulnerable image with digest {img.digest}? [y/N]'
+    prompt = f'Delete vulnerable image with digest {img.digest}? [y/n]'
 
     while True:
         sys.stdout.write(prompt)
@@ -50,7 +63,6 @@ def prompt_for_deletion(img):
             break
         else:
             continue
-
 
 def get_image_digests():
     untagged_images = subprocess.check_output(f"""
@@ -89,6 +101,7 @@ if __name__ == '__main__':
     for img in candidates_for_deletion:
         img.scan(args.os_version, args.min_severity)
 
+    # determine which images should be deleted
     for img in candidates_for_deletion:
         if args.delete_all:
             for img in candidates_for_deletion:

--- a/tools/clean-ecr
+++ b/tools/clean-ecr
@@ -1,0 +1,45 @@
+#! /usr/bin/env python
+
+import os
+import subprocess
+import argparse
+import json
+
+
+admin_arn = os.environ.get('ADMIN_ARN')
+#env = os.environ.get('ENVIRONMENT')
+ecr_account_to_use = os.environ.get('ECR_ACCOUNT_TO_USE')
+image_repo = os.environ.get('IMAGE_REPO')
+#deployment_name = os.environ.get('DEPLOYMENT_NAME')
+
+
+def get_image_digests():
+    untagged_images = subprocess.check_output(f"""
+        awsudo -d 3600 {admin_arn} aws ecr list-images
+        --registry-id {ecr_account_to_use}
+        --repository-name {image_repo}
+        --filter tagStatus=UNTAGGED""".split()
+    )
+    digests = json.loads(untagged_images)['imageIds']
+    return [i['imageDigest'] for i in digests]
+
+
+def main(delete_all):
+    digests = get_image_digests()
+    print(digests)
+
+
+
+
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description='Find and delete images in ECR that are failing security scans and are untagged'
+    )
+    parser.add_argument(
+        '--all', dest='delete_all', action='store_true', default=False,
+        help='don\'t prompt whether to delete each image, just delete all eligible')
+    args = parser.parse_args()
+
+    main(args.delete_all)

--- a/tools/clean-ecr
+++ b/tools/clean-ecr
@@ -52,7 +52,7 @@ class Image(object):
 
 
 def prompt_for_deletion(img):
-    valid_inputs = {'y': True,'n': False}
+    valid_inputs = {'y': True, 'n': False}
     prompt = f'Delete vulnerable image with digest {img.digest}? [y/n]'
 
     while True:

--- a/tools/clean-ecr
+++ b/tools/clean-ecr
@@ -37,35 +37,40 @@ DELETE_LEVELS = {
 
 class Image(object):
 
-    def __init__(self, digest, min_severity):
+    def __init__(self, digest):
         self.digest = digest
-        self.min_severity = min_severity
-        self.insecure = False
+        self.insecure = True
         self.can_delete = False
         self.to_delete = False
-        self.highest_severity_found = None
 
     def scan(self, os_version, min_severity):
-        scan_output = '/tmp/scan-report.out'
+        scan_output = None
         try:
-            scan_output = subprocess.check_output(f'image-scan-report {os_version} {min_severity} --image-digest {self.digest} > {scan_output}'.split())
-        except subprocess.CalledProcessError:
-            self.insecure = True
-            print(f'Insecure image detected: {self.digest}')
+            proc = subprocess.Popen(
+                f'image-scan-report {os_version} {min_severity} --image-digest {self.digest}'.split(),
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            )
+            scan_output, err = proc.communicate()
+            if proc.returncode == 0:
+                self.insecure = False
         except Exception as e:
             raise e
 
         if self.insecure:
-            scan_results = None
-            with open(scan_output) as f:
-                scan_results = f.read()
-            os.remove(scan_output)
-            print(scan_results)
+            print()
+            # THIS IS EMPTY
+            print(scan_output)
+            print()
 
-            fail_levels = DELETE_LEVELS[self.min_severity]
+            fail_levels = DELETE_LEVELS[min_severity]
             for l in fail_levels:
-                if l in scan_results:
-                    selt.can_delete = True
+                if l in str(scan_output):
+                    self.can_delete = True
+                    print(f'Insecure image detected: {self.digest}')
+
+
+
+
 
     def delete(self):
         subprocess.check_output(f"""
@@ -103,7 +108,7 @@ def get_image_digests():
 def main(args):
     # find candidates for deletion (all untagged images in a repo)
     for d in get_image_digests():
-        CANDIDATES_FOR_DELETION.append(Image(d, min_severity))
+        CANDIDATES_FOR_DELETION.append(Image(d))
 
     # scan each image for vulnerabilities
     for img in CANDIDATES_FOR_DELETION:
@@ -120,7 +125,8 @@ def main(args):
     # delete images
     for img in CANDIDATES_FOR_DELETION:
         if img.to_delete:
-            img.delete()
+            pass
+            #img.delete()
 
 
 if __name__ == '__main__':

--- a/tools/clean-ecr
+++ b/tools/clean-ecr
@@ -18,9 +18,10 @@ insecure.
 Run "clean-ecr --help" for usage information.
 """
 
-admin_arn = os.environ.get('ADMIN_ARN')
-ecr_account_to_use = os.environ.get('ECR_ACCOUNT_TO_USE')
-image_repo = os.environ.get('IMAGE_REPO')
+ADMIN_ARN = os.environ.get('ADMIN_ARN')
+ECR_ACCOUNT_TO_USE = os.environ.get('ECR_ACCOUNT_TO_USE')
+IMAGE_REPO = os.environ.get('IMAGE_REPO')
+IMAGE_UBUNTU_NAME = os.environ.get('IMAGE_UBUNTU_NAME')
 
 candidates_for_deletion = []
 
@@ -43,9 +44,9 @@ class Image(object):
 
     def delete(self):
         subprocess.check_output(f"""
-            awsudo -d 3600 {admin_arn} aws ecr batch-delete-image
-            --registry-id {ecr_account_to_use}
-            --repository-name {image_repo}
+            awsudo -d 3600 {ADMIN_ARN} aws ecr batch-delete-image
+            --registry-id {ECR_ACCOUNT_TO_USE}
+            --repository-name {IMAGE_REPO}
             --image-ids imageDigest={self.digest}""".split()
         )
         print(f'Deleted image with digest: {self.digest}')
@@ -66,33 +67,15 @@ def prompt_for_deletion(img):
 
 def get_image_digests():
     untagged_images = subprocess.check_output(f"""
-        awsudo -d 3600 {admin_arn} aws ecr list-images
-        --registry-id {ecr_account_to_use}
-        --repository-name {image_repo}
+        awsudo -d 3600 {ADMIN_ARN} aws ecr list-images
+        --registry-id {ECR_ACCOUNT_TO_USE}
+        --repository-name {IMAGE_REPO}
         --filter tagStatus=UNTAGGED""".split()
     )
     digests = json.loads(untagged_images)['imageIds']
     return [i['imageDigest'] for i in digests]
 
-
-if __name__ == '__main__':
-    parser = argparse.ArgumentParser(
-        description='Find and delete images in ECR that are failing security scans and are untagged'
-    )
-    parser.add_argument(
-        '--all', dest='delete_all', action='store_true', default=False,
-        help='don\'t prompt whether to delete each image, just delete all untagged insecure images'
-    )
-    parser.add_argument(
-        '--os-version', dest='os_version', action='store', default='Focal',
-        help='Ubuntu version substring (default is "Focal")'
-    )
-    parser.add_argument(
-        '--min-severity-level', dest='min_severity', action='store', default='HIGH',
-        help='minimum severity level of vulnerabilities (default is "HIGH")'
-    )
-    args = parser.parse_args()
-
+def main(delete_all, os_version, min_severity):
     # find candidates for deletion (all untagged images in a repo)
     for d in get_image_digests():
         candidates_for_deletion.append(Image(d))
@@ -113,3 +96,24 @@ if __name__ == '__main__':
     for img in candidates_for_deletion:
         if img.to_delete:
             img.delete()
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description='Find and delete images in ECR that are failing security scans and are untagged'
+    )
+    parser.add_argument(
+        '--all', dest='delete_all', action='store_true', default=False,
+        help='don\'t prompt whether to delete each image, just delete all untagged insecure images'
+    )
+    parser.add_argument(
+        '--os-version', dest='os_version', action='store', default=IMAGE_UBUNTU_NAME,
+        help='Ubuntu version substring (e.g. "Groovy")'
+    )
+    parser.add_argument(
+        '--min-severity-level', dest='min_severity', action='store', default='HIGH',
+        help='minimum severity level of vulnerabilities (default is "HIGH")'
+    )
+    args = parser.parse_args()
+
+    main(delete_all, os_version, min_severity)

--- a/tools/image-login
+++ b/tools/image-login
@@ -2,4 +2,4 @@
 
 # Log into AWS ECR based on the current shell environment.
 
-awsudo ${ADMIN_ARN} aws ecr get-login-password --region=us-east-1 | docker login --username AWS --password-stdin ${ECR_ACCOUNT_TO_USE}
+awsudo ${ADMIN_ARN} aws ecr get-login-password --region=us-east-1 | docker login --username AWS --password-stdin ${ECR_REGISTRY}

--- a/tools/image-scan-report
+++ b/tools/image-scan-report
@@ -119,7 +119,7 @@ def fetch_ubuntu_uri_status(uri, version_name):
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('version', help='Ubuntu version substring, e.g. Focal')
+    parser.add_argument('version', help='Ubuntu version substring, e.g. Groovy')
     parser.add_argument('levels', help='Minimum severity level, e.g. MEDIUM')
     parser.add_argument('--image-digest', dest='image_digest', help='Digest of image to scan, e.g. sha256:*')
     args = parser.parse_args()

--- a/tools/image-scan-report
+++ b/tools/image-scan-report
@@ -47,6 +47,7 @@ def get_scan_results(image_digest):
     admin_arn=os.environ["ADMIN_ARN"]
     image_repo=os.environ["IMAGE_REPO"]
     image_tag=os.environ["IMAGE_TAG"]
+    ecr_account_to_use=os.environ["ECR_ACCOUNT_TO_USE"]
 
     image_id_arg = f"imageTag={image_tag}"
     if image_digest:
@@ -56,6 +57,7 @@ def get_scan_results(image_digest):
         f"awsudo -d 3600 {admin_arn}  aws ecr describe-image-scan-findings "
         f"--no-paginate "
         f"--repository-name {image_repo} "
+        f"--registry-id {ecr_account_to_use} "
         f"--image-id {image_id_arg}").split())
     return json.loads(scan_results)
 


### PR DESCRIPTION
Directly from the docstring:

> This tool scans an ECR repository to find images with vulnerabilities.
> Images that are tagged are ignored.  All untagged images that are found to have
> vulnerabilities are considered to be candidates for deletion.
>
> Interactive and automated actions are both supported.  By default, this tool
> will ask you to confirm deletion of each image that has been found to be
> insecure.
>
> Run "clean-ecr --help" for usage information.

I tested both interactive and automated modes on the local Roman DEV account (not the central ECR account).

I also changed some of the global variable names to make more sense.  I've grep'd to see if these changes will impact any other scripts, and I don't think they will.

NOTE: I took the approach of ignoring all tagged images.  We will be notified via email if a tagged image is failing security scans, and that would require manual intervention.