### PR TITLE
Version tools

### DIFF
--- a/deployments/common/image/common-scripts/dump-versions
+++ b/deployments/common/image/common-scripts/dump-versions
@@ -1,0 +1,108 @@
+#! /usr/bin/env python
+
+import os
+import subprocess
+import glob
+from collections import defaultdict
+
+import yaml
+
+
+def run(cmd):
+    result = subprocess.run(
+        cmd.split(),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        check=True,
+    )  # maybe succeeds
+    return result.stdout
+
+
+def envs():
+    return set(
+        run("/opt/common-scripts/env-list-dirs /opt/environments").splitlines()
+    ) - set(["frozen"])
+
+
+def load_spec(path):
+    with open(path) as file_:
+        if path.endswith(".yml"):
+            spec = yaml.full_load(file_)
+        elif path.endswith((".pip", ".conda")):
+            spec = [line for line in file_.read().splitlines() if line.strip()]
+        else:
+            raise ValueError("Unhandled spec extension for: " + repr(path))
+    return spec
+
+
+def get_frozen():
+    frozen = {}
+    for env in envs():
+        frozen[env] = load_spec(f"/opt/environments/frozen/{env}-frozen.yml")
+    return frozen
+
+
+def get_pkg_lists():
+    pkgs = defaultdict(dict)
+    for env in envs():
+        for spec in glob.glob(f"/opt/environments/{env}/*"):
+            if spec.endswith((".yml", ".pip", ".conda")):
+                pkgs[env][spec] = load_spec(spec)
+    return dict(pkgs)
+
+
+def get_apt_pkgs():
+    lines = run("apt list").splitlines()
+    if lines[1].startswith("WARNING: apt does not have a stable CLI"):
+        lines = lines[4:]
+    return { line.split()[0]: line.split()[1] for line in lines }
+
+
+def get_labextensions():
+    lines = [
+        " ".join(line.strip().split()[:2])
+        for line in run("jupyter labextension list").splitlines()
+    ]
+    exts = dict([line.split() for line in lines if len(line.split()) == 2])
+    exts.pop("app", None)
+    exts.pop("Other", None)
+    return exts
+
+
+def get_nbextensions():
+    lines = [
+        " ".join(line.strip().split()[:1])
+        for line in run("jupyter nbextension list").splitlines()
+        if "Validating" not in line
+    ]
+    lines.remove("Known")
+    lines.remove("config")
+    return lines
+
+
+def get_npm():
+    lines = run("npm version").splitlines()[1:-1]
+    lines = [" ".join(line.split()[:2]) for line in lines]
+    lines = [line.replace("'", "") for line in lines]
+    lines = [line.replace(",", "") for line in lines]
+    lines = [line.replace(":", "") for line in lines]
+    return dict(line.split() for line in lines)
+
+
+def main():
+    versions = dict(
+        etc_issue=" ".join(run("cat /etc/issue").strip().split()[:2]),
+        uname=" ".join(run("uname -a").strip().split()),
+        apt_pkgs=get_apt_pkgs(),
+        npm=get_npm(),
+        jupyter_labextensions=get_labextensions(),
+        jupyter_nbextensions=get_nbextensions(),
+        kernel_frozen_specs=get_frozen(),
+        kernel_package_lists=get_pkg_lists(),
+    )
+    print(yaml.dump(versions))
+
+
+if __name__ == "__main__":
+    main()

--- a/deployments/roman/image/environments/frozen/cvt-frozen.yml
+++ b/deployments/roman/image/environments/frozen/cvt-frozen.yml
@@ -18,7 +18,7 @@ dependencies:
   - beautifulsoup4=4.9.3
   - blas=2.109
   - blas-devel=3.9.0
-  - bleach=3.3.0
+  - bleach=3.3.1
   - blinker=1.4
   - blosc=1.21.0
   - bokeh=2.3.3
@@ -39,12 +39,13 @@ dependencies:
   - cfitsio=3.470
   - chardet=4.0.0
   - charls=2.2.0
+  - charset-normalizer=2.0.0
   - click=8.0.1
   - cloudpickle=1.6.0
   - conda=4.10.3
   - conda-package-handling=1.7.3
   - conda-tree=0.1.1
-  - configurable-http-proxy=4.4.0
+  - configurable-http-proxy=4.5.0
   - cryptography=3.4.7
   - cycler=0.10.0
   - cython=0.29.24
@@ -69,13 +70,13 @@ dependencies:
   - hdf5=1.10.6
   - heapdict=1.0.1
   - icu=68.1
-  - idna=2.10
+  - idna=3.1
   - imagecodecs=2021.6.8
   - imageio=2.9.0
   - importlib-metadata=4.6.1
   - ipydatawidgets=4.2.0
-  - ipyevents=0.8.2
-  - ipykernel=6.0.1
+  - ipyevents=2.0.1
+  - ipykernel=6.0.3
   - ipympl=0.7.0
   - ipython=7.25.0
   - ipython_genutils=0.2.0
@@ -163,7 +164,7 @@ dependencies:
   - notebook=6.4.0
   - numba=0.53.1
   - numexpr=2.7.3
-  - numpy=1.21.0
+  - numpy=1.21.1
   - oauthlib=3.1.1
   - olefile=0.46
   - openblas=0.3.15
@@ -201,7 +202,7 @@ dependencies:
   - pysocks=1.7.1
   - pytables=3.6.1
   - python=3.9.5
-  - python-dateutil=2.8.1
+  - python-dateutil=2.8.2
   - python-editor=1.0.4
   - python-json-logger=2.0.1
   - python-libarchive-c=3.1
@@ -213,7 +214,7 @@ dependencies:
   - readline=8.1
   - reproc=14.2.1
   - reproc-cpp=14.2.1
-  - requests=2.25.1
+  - requests=2.26.0
   - requests-unixsocket=0.2.0
   - ripgrep=13.0.0
   - ruamel.yaml=0.17.10
@@ -231,7 +232,7 @@ dependencies:
   - sniffio=1.2.0
   - sortedcontainers=2.4.0
   - soupsieve=2.0.1
-  - sqlalchemy=1.4.20
+  - sqlalchemy=1.4.21
   - sqlite=3.36.0
   - statsmodels=0.12.2
   - sympy=1.8
@@ -271,9 +272,9 @@ dependencies:
     - astropy==4.2.1
     - astropy-sphinx-theme==1.1
     - async-timeout==3.0.1
-    - black==21.6b0
-    - boto3==1.17.111
-    - botocore==1.20.111
+    - black==21.7b0
+    - boto3==1.18.2
+    - botocore==1.21.2
     - bqplot==0.12.27
     - ci-watson==0.5
     - codecov==2.1.11
@@ -307,7 +308,7 @@ dependencies:
     - nbgitpuller==0.10.1
     - numpydoc==1.1.0
     - papermill==2.3.3
-    - pathspec==0.8.1
+    - pathspec==0.9.0
     - pipdeptree==2.0.0
     - pluggy==0.13.1
     - py==1.10.0
@@ -325,7 +326,7 @@ dependencies:
     - qtpy==1.9.0
     - regex==2021.7.6
     - requests-mock==1.9.3
-    - s3transfer==0.4.2
+    - s3transfer==0.5.0
     - simpervisor==0.4
     - snowballstemmer==2.1.0
     - sphinx==3.5.4
@@ -345,6 +346,7 @@ dependencies:
     - tenacity==8.0.1
     - textwrap3==0.9.2
     - toml==0.10.2
-    - vispy==0.7.1
+    - tomli==1.0.4
+    - vispy==0.7.2
     - yarl==1.6.3
 prefix: /opt/conda/envs/cvt

--- a/deployments/roman/image/environments/frozen/roman-cal-frozen.yml
+++ b/deployments/roman/image/environments/frozen/roman-cal-frozen.yml
@@ -29,7 +29,7 @@ dependencies:
   - libopenblas=0.3.15
   - libstdcxx-ng=9.3.0
   - ncurses=6.2
-  - numpy=1.21.0
+  - numpy=1.21.1
   - openssl=1.1.1k
   - pip=21.1.3
   - pycosat=0.6.3
@@ -40,6 +40,7 @@ dependencies:
   - python=3.8.10
   - python_abi=3.8
   - readline=8.1
+  - requests=2.26.0
   - ruamel_yaml=0.15.80
   - setuptools=49.6.0
   - six=1.16.0
@@ -72,21 +73,21 @@ dependencies:
     - babel==2.9.1
     - backcall==0.2.0
     - beautifulsoup4==4.9.3
-    - black==21.6b0
-    - bleach==3.3.0
+    - black==21.7b0
+    - bleach==3.3.1
     - bokeh==2.3.3
-    - boto3==1.17.111
-    - botocore==1.20.111
+    - boto3==1.18.2
+    - botocore==1.21.2
     - bottleneck==1.3.2
     - bqplot==0.12.27
-    - bqplot-image-gl==1.4.2
-    - charset-normalizer==2.0.1
+    - bqplot-image-gl==1.4.3
+    - charset-normalizer==2.0.3
     - ci-watson==0.5
     - click==8.0.1
     - codecov==2.1.11
     - coverage==5.5
-    - crds==11.0.4
-    - cubeviz==0.3.1
+    - crds==11.1.0
+    - cubeviz==0.3.0
     - cycler==0.10.0
     - cython==0.29.24
     - debugpy==1.3.0
@@ -120,9 +121,9 @@ dependencies:
     - importlib-resources==5.2.0
     - iniconfig==1.1.1
     - ipydatawidgets==4.2.0
-    - ipyevents==0.8.2
+    - ipyevents==2.0.1
     - ipygoldenlayout==0.4.0
-    - ipykernel==6.0.1
+    - ipykernel==6.0.3
     - ipympl==0.7.0
     - ipysplitpanes==0.2.0
     - ipython==7.25.0
@@ -151,7 +152,7 @@ dependencies:
     - jupyterlab-pygments==0.1.2
     - jupyterlab-server==2.6.1
     - jupyterlab-widgets==1.0.0
-    - jwst==1.1.0
+    - jwst==1.2.3
     - jwst-backgrounds==1.1.2
     - jwst-footprints==2.4.2
     - jwst-pancake==1.0.0rc2
@@ -186,7 +187,7 @@ dependencies:
     - papermill==2.3.3
     - parsley==1.3
     - parso==0.8.2
-    - pathspec==0.8.1
+    - pathspec==0.9.0
     - pexpect==4.8.0
     - photutils==1.1.0
     - pickleshare==0.7.5
@@ -229,11 +230,12 @@ dependencies:
     - qtpy==1.9.0
     - radio-beam==0.3.3
     - regex==2021.7.6
-    - requests==2.26.0
     - requests-mock==1.9.3
     - requests-unixsocket==0.2.0
-    - romancal==0.2.0
-    - s3transfer==0.4.2
+    - roman-datamodels==0.2.0
+    - romanad==0.3.0
+    - romancal==0.3.1
+    - s3transfer==0.5.0
     - scikit-image==0.18.2
     - scikit-learn==0.24.2
     - scipy==1.7.0
@@ -261,6 +263,7 @@ dependencies:
     - sphinxcontrib-jsmath==1.0.1
     - sphinxcontrib-qthelp==1.0.3
     - sphinxcontrib-serializinghtml==1.1.5
+    - stcal==0.2.2
     - stdatamodels==0.2.3
     - stpipe==0.2.0
     - stsci-image==2.3.3
@@ -277,13 +280,14 @@ dependencies:
     - threadpoolctl==2.2.0
     - tifffile==2021.7.2
     - toml==0.10.2
+    - tomli==1.0.4
     - toolz==0.11.1
     - tornado==6.1
     - traitlets==5.0.5
     - traittypes==0.2.1
     - tweakwcs==0.7.2
     - typing-extensions==3.10.0.0
-    - vispy==0.7.1
+    - vispy==0.7.2
     - wcwidth==0.2.5
     - webbpsf==0.9.1
     - webencodings==0.5.1

--- a/deployments/roman/image/environments/roman-cal/roman-cal.pip
+++ b/deployments/roman/image/environments/roman-cal/roman-cal.pip
@@ -1,2 +1,2 @@
-jwst==1.1.0
-romancal==0.2.0
+jwst~=1.2.3
+romancal~=0.3.1

--- a/doc/DEPLOYMENT.md
+++ b/doc/DEPLOYMENT.md
@@ -171,6 +171,13 @@ Now we need to create a *environment.yaml* file.  During JupyterHub deployment, 
 - Fill in the areas that say "[REDACTED]" with the appropriate values, then save and exit the editor.
 - `git add $ENVIRONMENT.yaml .sops.yaml`
 
+To support pushing secrets back to codecommit you need to set up a credentials helper with:
+
+``` 
+git config --global credential.helper '!aws codecommit credential-helper $@' 
+git config --global credential.UseHttpPath true
+```
+
 Finally, commit and push the changes to the repository:
 
 - `git commit -m "adding secrets"`

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,6 @@ lxml
 pyyaml
 safety
 bandit
+boto3
+flake8
+black

--- a/setup-env.template
+++ b/setup-env.template
@@ -11,11 +11,13 @@ export CENTRAL_ECR_ACCOUNT_ID=12345678
 export USE_CENTRAL_ECR=false
 export ADMIN_ROLENAME=aws-admin-role
 export DEPLOYMENT_NAME=cluster-name
-export IMAGE_TAG=latest
-export COMMON_TAG=common-latest
+export ENVIRONMENT=sandbox  # sandbox, dev, test, or prod
 
-# sandbox, dev, test, or prod
-export ENVIRONMENT=sandbox
+# Note that unscanned- tags are pushed, pulled, and scanned but
+# the unscanned- is dropped from images permitted on the hub by
+# virtue of passing ECR scanning.
+export IMAGE_TAG=unscanned-latest-${ENVIRONMENT}
+export COMMON_TAG=unscanned-common-latest-${ENVIRONMENT}
 
 # ----------------- vvvv less frequently changed vvvv -------------------------------
 

--- a/setup-env.template
+++ b/setup-env.template
@@ -22,7 +22,7 @@ export COMMON_TAG=unscanned-common-latest-${ENVIRONMENT}
 # ----------------- vvvv less frequently changed vvvv -------------------------------
 
 # use 0 for loosely pinned package versions,  1 production build from fixed versions.
-export USE_FROZEN=1
+export USE_FROZEN=0
 
 # Set to 1 for e.g. personal laptop build
 export PERSONAL_IMAGE=0

--- a/tools/image-cp
+++ b/tools/image-cp
@@ -1,0 +1,13 @@
+#! /bin/bash
+
+set -eu
+
+#     usage:  image-cp   <path-inside-container>   [<path-on-host> or PWD]
+#
+#     Copy the specified filepath out of the currently configured image
+#     to the specified location on the host or the PWD.
+
+PATH_TO_EXPORT=$1
+WHERE_TO_PUT_IT=${2:-`pwd`}
+
+docker run --rm -it -v ${WHERE_TO_PUT_IT}:/opt/mount ${IMAGE_ID}  bash -c "cp -ar ${PATH_TO_EXPORT} /opt/mount/`basename ${PATH_TO_EXPORT}`"

--- a/tools/image-delete
+++ b/tools/image-delete
@@ -16,6 +16,6 @@ for image in ${IMAGES}; do
     else
 	QUALIFIER=imageTag
     fi
-    awsudo ${ADMIN_ARN} aws ecr batch-delete-image --repository-name ${IMAGE_REPO} --image-ids ${QUALIFIER}=${image}
+    awsudo ${ADMIN_ARN} aws ecr batch-delete-image --registry-id ${ECR_ACCOUNT_TO_USE} --repository-name ${IMAGE_REPO} --image-ids ${QUALIFIER}=${image}
 done
 

--- a/tools/image-pull
+++ b/tools/image-pull
@@ -5,5 +5,6 @@ cd $IMAGE_DIR
 image-login
 
 echo "================================== Pulling ${IMAGE_ID} =============================="
+echo "WARNING:  this is pulling the *unscanned* tag"
 docker image rm $IMAGE_ID
 docker pull $IMAGE_ID

--- a/tools/image-push
+++ b/tools/image-push
@@ -6,8 +6,5 @@ cd $IMAGE_DIR
 
 image-login
 
-UNSCANNED_ID=`echo $IMAGE_ID | perl -pi -e "s/:latest/:unscanned-latest-${ENVIRONMENT}/g"`
-
-echo "================================== Pushing ${IMAGE_ID} as ${UNSCANNED_ID} =============================="
-docker image tag $IMAGE_ID $UNSCANNED_ID
-docker push ${UNSCANNED_ID}
+echo "================================== Pushing ${IMAGE_ID} as ${IMAGE_ID} =============================="
+docker push ${IMAGE_ID}

--- a/tools/image-scan
+++ b/tools/image-scan
@@ -1,7 +1,7 @@
 #! /bin/bash -eu
-echo "============================== ECR Docker Image Vulnerability Scan ============================="
+echo "=========== ECR Docker Image Vulnerability Scan for $IMAGE_ID"
 cd  $JUPYTERHUB_DIR
 image-scan-report "$IMAGE_UBUNTU_NAME" $IMAGE_VULNERABILITY_LEVEL >ecr-scan-report.yaml
 
-echo "============================== ECR Scan Summary ================================"
+echo "=========== ECR Scan Summary ================================"
 image-scan-summary ecr-scan-report.yaml

--- a/tools/image-scan-report
+++ b/tools/image-scan-report
@@ -53,11 +53,13 @@ def get_scan_results(image_digest):
     if image_digest:
         image_id_arg = f"imageDigest={image_digest}"
 
+    print(f"Fetching ECR vulnerability scan for registry={ecr_account_to_use} repo={image_repo} tag={image_tag}",file=sys.stderr)
+
     scan_results = subprocess.check_output((
         f"awsudo -d 3600 {admin_arn}  aws ecr describe-image-scan-findings "
         f"--no-paginate "
-        f"--repository-name {image_repo} "
         f"--registry-id {ecr_account_to_use} "
+        f"--repository-name {image_repo} "
         f"--image-id {image_id_arg}").split())
     return json.loads(scan_results)
 
@@ -91,7 +93,6 @@ def get_report_dict(version, levels, image_digest):
     have severities in `levels` and the Ubuntu status string for the CVE for
     Ubuntu `version`.
     """
-    print("Fetching ECR vulnerability scan",file=sys.stderr)
     sys.stderr.flush()
     vulnerabilities = get_scan_results(image_digest)
     while vulnerabilities["imageScanStatus"]["status"] != "COMPLETE":

--- a/tools/versions
+++ b/tools/versions
@@ -1,0 +1,38 @@
+#! /usr/bin/env python
+
+# This script dumps the combined host and image s/w versions needed to characterize a hub.
+
+import os
+import subprocess
+import glob
+import argparse
+
+from collections import defaultdict
+from contextlib import contextmanager
+
+import yaml
+
+
+def run(cmd, cwd="."):
+    result = subprocess.run(
+        cmd.split(),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        check=True,
+	cwd=cwd,
+    )  # maybe succeeds
+    return result.stdout
+
+
+def main():
+    combined = dict(
+        host = yaml.full_load(run("versions-host")),
+        image = yaml.full_load(run("versions-image")),
+    )
+    print(yaml.dump(combined))
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tools/versions-host
+++ b/tools/versions-host
@@ -100,6 +100,7 @@ def main():
     host = dict(
         jupyterhub_deploy = get_git_version("/home/ec2-user/jupyterhub-deploy"),
         terraform_deploy = get_git_version("/home/ec2-user/terraform-deploy"),
+        jupyter_docker_stacks = get_git_version("/home/ec2-user/docker-stacks"),
         terraform = get_terraform(),
         helm = get_helm(),
         python_env = get_python_env(),

--- a/tools/versions-host
+++ b/tools/versions-host
@@ -1,0 +1,112 @@
+#! /usr/bin/env python
+
+# This script is used to dump the versions of all s/w which is
+# critical to the hub,  broadly in two sections,  one for the image
+# and one for terraform and hub setup.
+
+import os
+import subprocess
+import glob
+import argparse
+
+from collections import defaultdict
+from contextlib import contextmanager
+
+import yaml
+
+
+
+for envvar in ["ADMIN_ARN", "DEPLOYMENT_NAME"]:
+    globals()[envvar] =  os.environ[envvar]
+
+
+
+def run(cmd, cwd="."):
+    result = subprocess.run(
+        cmd.split(),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        check=True,
+	cwd=cwd,
+    )  # maybe succeeds
+    return result.stdout
+
+
+@contextmanager
+def cwd(dir):
+    old = os.getcwd()
+    os.chdir(dir)
+    try:
+       yield
+    finally:
+       os.chdir(old)
+
+
+def get_terraform():
+    with cwd("/home/ec2-user/terraform-deploy/aws"):
+        extract = {}
+        files = glob.glob("*.tf")
+        for file in files:
+            lines = open(file).read().splitlines()
+            extract.update(adjacent_lines(lines, "source", "version"))
+            extract.update(adjacent_lines(lines, "chart", "version"))
+        return dict(
+            pkgs = extract,
+	    terraform = run("terraform version").splitlines()[0].split()[1],
+            eks = get_eks_version(),
+	)
+
+
+def adjacent_lines(lines, first, next):
+    extract = {}
+    for i in range(len(lines)-1):
+        first_words = lines[i].split()
+        next_words = lines[i+1].split()
+        if len(first_words) < 3 or len(next_words) < 3:
+            continue
+        if first_words[0] == first and next_words[0] == next:
+            efirst = first_words[2].replace('"','')
+            enext = next_words[2].replace('"', '')
+            if enext == "~>":
+               enext = next_words[3].replace('"', '')
+            extract[efirst] = enext
+    return extract
+
+def get_eks_version():
+    lines = run(f"awsudo {ADMIN_ARN} aws eks describe-cluster --name {DEPLOYMENT_NAME}").splitlines()
+    for line in lines:
+        if "version" in line:
+            return line.split('"')[3]
+    return "UNDEFINED"
+
+def  get_helm():
+    pkgs  =  [" ".join(line.split()) for line in run("helm list").splitlines() if not line.startswith(("WARNING","NAME"))],
+    return dict(
+       pkgs = pkgs,
+       helm = run("helm version").split('{')[1].split('}')[0].split(","),
+    )
+
+
+def get_python_env():
+    return yaml.full_load(run("conda env export"))
+
+def get_git_version(path):
+    with cwd(path):
+        return run("git log --no-color").splitlines()[0]
+
+
+def main():
+    host = dict(
+        jupyterhub_deploy = get_git_version("/home/ec2-user/jupyterhub-deploy"),
+        terraform_deploy = get_git_version("/home/ec2-user/terraform-deploy"),
+        terraform = get_terraform(),
+        helm = get_helm(),
+        python_env = get_python_env(),
+    )
+    print(yaml.dump(host))
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tools/versions-image
+++ b/tools/versions-image
@@ -1,0 +1,11 @@
+#! /bin/bash
+
+set -eu
+
+# Run /opt/common-scripts/dump-versions inside a running image/container
+
+export IMAGE_RUN_PARS="-e DEPLOYMENT_NAME=${DEPLOYMENT_NAME}  ${IMAGE_RUN_PARS}"
+
+image-exec /opt/common-scripts/dump-versions
+
+


### PR DESCRIPTION
Added some scripts used to dump s/w versions:

1. Inside the image
2. On the host

Scripts are:

1. tools/versions  (combined image + host)
2. tools/versions-image
3. tools/versions-host
4. /opt/common-scripts/dump-version  (runs inside notebook container)

Tweaked handling of IMAGE_TAG so it is set explicitly in setup-env to: 
    e.g. unscanned-latest-dev
and used unmodified for scripts which refer to it, IMAGE_ID, etc.

Note that config YAML files still refer to the approved image tags: 
   e.g.  latest-dev