### PR TITLE
Tike test ops setup

### DIFF
--- a/derived-env
+++ b/derived-env
@@ -42,3 +42,11 @@ export PATH="`pwd`/tools":${PATH}
 export TMOUT=7200
 export TF_LOG=TRACE
 export TF_LOG_PATH=terraform.log
+
+alias awsu="awsudo -d 3600 $ADMIN_ARN"
+alias terraform-init="awsu terraform init -backend-config=./backend.conf -backend-config=./backend.conf"
+alias terraform-apply="awsu terraform apply --var-file=${DEPLOYMENT_NAME}.tfvars"
+alias terraform-destroy="awsu terraform destroy -var-file=${DEPLOYMENT_NAME}.tfvars"
+alias helm-destroy="awsu helm uninstall ${DEPLOYMENT_NAME}-${ENVIRONMENT}"
+alias where="echo ${DEPLOYMENT_NAME}-${ENVIRONMENT}"
+

--- a/doc/example-common.yaml
+++ b/doc/example-common.yaml
@@ -39,9 +39,9 @@ jupyterhub:
       limit: 15G
   auth:
     users:
-      - [EMAIL ADDRESS]
+      - EMAIL ADDRESS
       - ...
     admin:
       users:
-        - [EMAIL ADDRESS]
+        - EMAIL ADDRESS
         - ...

--- a/doc/example-secrets-env-decrypted.yaml
+++ b/doc/example-secrets-env-decrypted.yaml
@@ -1,6 +1,6 @@
 jupyterhub:
     proxy:
-        secretToken: [REDACTED]
+        secretToken: "REDACTED"
         https:
             enabled: true
             type: manual
@@ -9,18 +9,18 @@ jupyterhub:
             manual:
                 key: |
                     -----BEGIN RSA PRIVATE KEY-----
-                    [REDACTED]
+                    REDACTED
                     -----END RSA PRIVATE KEY-----
                 cert: |
                     -----BEGIN CERTIFICATE-----
-                    [REDACTED]
+                    REDACTED
                     -----END CERTIFICATE-----
     hub:
         config:
             GenericOAuthenticator:
                 authorize_url: https://auth.masttest.stsci.edu/oauth/authorize
-                client_id: [REDACTED] 
-                client_secret: [REDACTED] 
+                client_id: "REDACTED" 
+                client_secret: "REDACTED" 
                 login_service: MAST
                 oauth_callback_url: https://[URL]/hub/oauth_callback
                 scope:

--- a/hub/custom-ui-templates-prod-tike.yaml
+++ b/hub/custom-ui-templates-prod-tike.yaml
@@ -1,0 +1,55 @@
+# Inspired by https://gitmemory.com/issue/jupyterhub/zero-to-jupyterhub-k8s/1266/632726020
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hub-templates
+data:
+  spawn.html: |
+    {% extends "page.html" %}
+    {% if announcement_spawn %}
+      {% set announcement = announcement_spawn %}
+    {% endif %}
+
+    {% block main %}
+
+    <div class="container">
+      {% block heading %}
+       <div class="row">
+
+          <center><h2>Welcome to the Timeseries Integrated Knowledge Engine (TIKE)</h2></center><br/>
+
+          TIKE is a JupyterHub instance provided by the Space Telescope Science Institute (STScI), and its main goal is to increase the accessibility of scientific data and software. STScI's JupyterHub platforms achieve this by providing users with a pre-defined Linux computing environment hosted by Amazon Web Services (AWS), and by deploying these resouces in the same AWS region hosting MAST's <a href="https://registry.opendata.aws/collab/stsci">AWS Public Datasets</a>. TIKE is a collaboration between the <a href="https://archive.stsci.edu">Mikulski Archive for Space Telescopes (MAST)</a>, the Data Science Mission Office (DSMO), and the Community Missions Office (CMO). Its initial focus is on timeseries data, such as those available from the <a href="https://outerspace.stsci.edu/display/TESS/TESS+Archive+Manual">TESS</>, <a href="https://archive.stsci.edu/missions-and-data/kepler">Kepler</a>, and <a href="https://archive.stsci.edu/missions-and-data/k2">K2</a> missions, and this focus will expand in future releases.<br/><br/>
+
+          <b>Useful information</b>&#58;<br/><br/>
+
+            <ul>
+            <li>TIKE is currently <i><b>under active development</b></i> and as such, you should have no expectations regarding service uptime, data preservation, etc. We anticipate greater reliability as we approach a wider community release.  At this time, <u>no data</u> you upload or create within TIKE is guaranteed to remain for any duration.</li>
+              <li>TIKE is free to use, and users do <i><b>not</b></i> require an AWS account to use TIKE or to access STScI's <a href="https://registry.opendata.aws/collab/stsci">Public Datasets in AWS</a>.</li>
+              <li> Several resources are available to support TIKE usage, and we expect more to be added in the coming months. At this time, the main source is the <a href="https://github.com/spacetelescope/tike_content">TIKE_content Github repository</a>.</li>
+              <ul><li>Additional introductory material is available by drilling down in the above repository, for example&#58; <a href="https&#58;//github.com/spacetelescope/tike_content/blob/master/content/Introduction.md">https&#58;//github.com/spacetelescope/tike_content/blob/master/content/Introduction.md</a></li></ul>
+              <li>This service offers no reasonable expectation of privacy. Usage is monitored, and access will be restricted as needed in order to provide an acceptable level of service to all users.</li>
+            </ul><br/>
+            At this time, we cannot guarantee prompt responses to any support requests.
+
+        <br/><br/><br/>
+       </div>
+      {% endblock %}
+      <div class="row col-sm-offset-2 col-sm-8">
+        {% if for_user and user.name != for_user.name -%}
+          <p>Spawning server for {{ for_user.name }}</p>
+        {% endif -%}
+        {% if error_message -%}
+          <p class="spawn-error-msg text-danger">
+            Error: {{error_message}}
+          </p>
+        {% endif %}
+        <form enctype="multipart/form-data" id="spawn_form" action="{{url}}" method="post" role="form">
+          {{spawner_options_form | safe}}
+          <br>
+          <input type="submit" value="Start server" class="btn btn-jupyter form-control">
+        </form>
+      </div>
+    </div>
+
+    {% endblock %}

--- a/hub/custom-ui-templates-test-tike.yaml
+++ b/hub/custom-ui-templates-test-tike.yaml
@@ -1,0 +1,55 @@
+# Inspired by https://gitmemory.com/issue/jupyterhub/zero-to-jupyterhub-k8s/1266/632726020
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hub-templates
+data:
+  spawn.html: |
+    {% extends "page.html" %}
+    {% if announcement_spawn %}
+      {% set announcement = announcement_spawn %}
+    {% endif %}
+
+    {% block main %}
+
+    <div class="container">
+      {% block heading %}
+       <div class="row">
+
+          <center><h2>Welcome to the Timeseries Integrated Knowledge Engine (TIKE)</h2></center><br/>
+
+          TIKE is a JupyterHub instance provided by the Space Telescope Science Institute (STScI), and its main goal is to increase the accessibility of scientific data and software. STScI's JupyterHub platforms achieve this by providing users with a pre-defined Linux computing environment hosted by Amazon Web Services (AWS), and by deploying these resouces in the same AWS region hosting MAST's <a href="https://registry.opendata.aws/collab/stsci">AWS Public Datasets</a>. TIKE is a collaboration between the <a href="https://archive.stsci.edu">Mikulski Archive for Space Telescopes (MAST)</a>, the Data Science Mission Office (DSMO), and the Community Missions Office (CMO). Its initial focus is on timeseries data, such as those available from the <a href="https://outerspace.stsci.edu/display/TESS/TESS+Archive+Manual">TESS</>, <a href="https://archive.stsci.edu/missions-and-data/kepler">Kepler</a>, and <a href="https://archive.stsci.edu/missions-and-data/k2">K2</a> missions, and this focus will expand in future releases.<br/><br/>
+
+          <b>Useful information</b>&#58;<br/><br/>
+
+            <ul>
+            <li>TIKE is currently <i><b>under active development</b></i> and as such, you should have no expectations regarding service uptime, data preservation, etc. We anticipate greater reliability as we approach a wider community release.  At this time, <u>no data</u> you upload or create within TIKE is guaranteed to remain for any duration.</li>
+              <li>TIKE is free to use, and users do <i><b>not</b></i> require an AWS account to use TIKE or to access STScI's <a href="https://registry.opendata.aws/collab/stsci">Public Datasets in AWS</a>.</li>
+              <li> Several resources are available to support TIKE usage, and we expect more to be added in the coming months. At this time, the main source is the <a href="https://github.com/spacetelescope/tike_content">TIKE_content Github repository</a>.</li>
+              <ul><li>Additional introductory material is available by drilling down in the above repository, for example&#58; <a href="https&#58;//github.com/spacetelescope/tike_content/blob/master/content/Introduction.md">https&#58;//github.com/spacetelescope/tike_content/blob/master/content/Introduction.md</a></li></ul>
+              <li>This service offers no reasonable expectation of privacy. Usage is monitored, and access will be restricted as needed in order to provide an acceptable level of service to all users.</li>
+            </ul><br/>
+            At this time, we cannot guarantee prompt responses to any support requests.
+
+        <br/><br/><br/>
+       </div>
+      {% endblock %}
+      <div class="row col-sm-offset-2 col-sm-8">
+        {% if for_user and user.name != for_user.name -%}
+          <p>Spawning server for {{ for_user.name }}</p>
+        {% endif -%}
+        {% if error_message -%}
+          <p class="spawn-error-msg text-danger">
+            Error: {{error_message}}
+          </p>
+        {% endif %}
+        <form enctype="multipart/form-data" id="spawn_form" action="{{url}}" method="post" role="form">
+          {{spawner_options_form | safe}}
+          <br>
+          <input type="submit" value="Start server" class="btn btn-jupyter form-control">
+        </form>
+      </div>
+    </div>
+
+    {% endblock %}

--- a/tools/deploy
+++ b/tools/deploy
@@ -21,7 +21,8 @@ pushd $(dirname ${secrets_yaml})
 awsudo $ADMIN_ARN sops --decrypt $(basename ${secrets_yaml}) > $tmp_decrypted
 
 popd
-helm upgrade --debug --wait --install ${deployment_name}-${environment} hub -f deployments/common/config/all.yaml -f deployments/${deployment_name}/config/common.yaml -f deployments/${deployment_name}/config/${environment}.yaml -f ${tmp_decrypted} --set-string jupyterhub.singleuser.image.name=${ECR_ACCOUNT_TO_USE}/${IMAGE_REPO}
+
+helm upgrade --debug --wait --install ${deployment_name}-${environment} hub -f deployments/common/config/all.yaml -f deployments/${deployment_name}/config/common.yaml -f deployments/${deployment_name}/config/${environment}.yaml -f ${tmp_decrypted} --set-string jupyterhub.singleuser.image.name=${ECR_REGISTRY}/${IMAGE_REPO}
 
 rm ~/env.yaml.decrypted
 

--- a/tools/image-promote-testops
+++ b/tools/image-promote-testops
@@ -2,4 +2,4 @@
 
 # promote Docker image from test to ops.
 
-image-promote $CENTRAL_ECR_ACCOUNT_ID $IMAGE_REPO latest-test latest
+image-promote $CENTRAL_ECR_ACCOUNT_ID $IMAGE_REPO latest-test latest-prod


### PR DESCRIPTION
Changes made for basic Tike TEST and OPS account setup.
Added custom ui templates for Tike TEST and OPS which are required for deploy-all.
Added convenience aliases to make some terraform-deploy tasks easier.
Modified image-promote-testops to use tag latest-prod instead of latest,  consistent with jwebbinar and Tike.
Tweaked templates which used YAML list notation as placeholders making it impossible to round-trip through sops since the placeholder was pretty printed from [ REDACTED ] to - REDACTED on a new line which is no longer a valid format.
Currently fixes image name bug in deploy script where ECR_ACCOUNT_TO_USE needs to be replaced by ECR_REGISTRY,  probably covered by other concurrent PR's,  may disappear from this merge.