### PR TITLE
Disable loading /home/shared for Roman; update deploy-jupyterhub

### DIFF
--- a/deployments/roman/config/dev.yaml
+++ b/deployments/roman/config/dev.yaml
@@ -8,32 +8,32 @@ jupyterhub:
       enabled: false
   singleuser:
     storage:
-      extraVolumes:
-      - name:  preloaded-fits-volume
-        persistentVolumeClaim:
-          claimName: preloaded-fits
-      - name:  preloaded-astropy-volume
-        persistentVolumeClaim:
-          claimName: preloaded-astropy
-      - name:  preloaded-crds-volume
-        persistentVolumeClaim:
-          claimName: preloaded-crds
-      extraVolumeMounts:
-      - name:  preloaded-fits-volume
-        mountPath: /home/shared/preloaded-fits
-        readOnly: true
-      - name:  preloaded-astropy-volume
-        mountPath: /home/shared/preloaded-astropy
-        readOnly: true
-      - name:  preloaded-crds-volume
-        mountPath: /home/shared/preloaded-crds
-        readOnly: true
-    lifecycleHooks:
-      postStart:
-        exec:
-          command:
-            - "sh"
-            - "-c"
-            - >
-              rsync -url /home/shared/preloaded-crds/ /home/jovyan/crds_cache;
-              rsync -url /home/shared/preloaded-astropy/ /home/jovyan/.astropy_cache;
+      #extraVolumes:
+      # - name:  preloaded-fits-volume
+      #  persistentVolumeClaim:
+      #    claimName: preloaded-fits
+      #- name:  preloaded-astropy-volume
+      #  persistentVolumeClaim:
+      #    claimName: preloaded-astropy
+      #- name:  preloaded-crds-volume
+      #  persistentVolumeClaim:
+      #    claimName: preloaded-crds
+      #extraVolumeMounts:
+      # - name:  preloaded-fits-volume
+      #  mountPath: /home/shared/preloaded-fits
+      #  readOnly: true
+      #- name:  preloaded-astropy-volume
+      #  mountPath: /home/shared/preloaded-astropy
+      #  readOnly: true
+      #- name:  preloaded-crds-volume
+      #  mountPath: /home/shared/preloaded-crds
+      #  readOnly: true
+  #lifecycleHooks:
+    #postStart:
+      #exec:
+        #command:
+        #    - "sh"
+        #    - "-c"
+        #    - >
+        #      rsync -url /home/shared/preloaded-crds/ /home/jovyan/crds_cache;
+        #      rsync -url /home/shared/preloaded-astropy/ /home/jovyan/.astropy_cache;

--- a/tools/deploy-jupyterhub
+++ b/tools/deploy-jupyterhub
@@ -28,7 +28,7 @@ pushd $(dirname ${secrets_yaml})
 awsudo $ADMIN_ARN sops --decrypt $(basename ${secrets_yaml}) > $tmp_decrypted
 popd
 
-helm upgrade --debug --wait --install ${DEPLOYMENT_NAME}-${ENVIRONMENT} hub -f ${COMMON_CONFIG_DIR}/all.yaml -f ${CONFIG_DIR}/common.yaml -f ${CONFIG_DIR}/${ENVIRONMENT}.yaml -f ${tmp_decrypted} --set-string jupyterhub.singleuser.image.name=${ECR_REGISTRY}/${IMAGE_REPO}
+helm upgrade --debug --wait --install ${DEPLOYMENT_NAME}-${ENVIRONMENT} hub -f ${COMMON_CONFIG_DIR}/all.yaml -f ${CONFIG_DIR}/common.yaml -f ${CONFIG_DIR}/${ENVIRONMENT}.yaml -f ${tmp_decrypted} --set-string jupyterhub.singleuser.image.name=${ECR_REGISTRY}/${IMAGE_REPO} --set-string jupyterhub.singleuser.image.tag="latest-${ENVIRONMENT}"
 
 rm ${tmp_decrypted}
 


### PR DESCRIPTION
`deploy-jupyterhub` needed to be updated to specify `jupyterhub.singleuser.image.tag` in the `helm install`.  Not quite sure why, but the image puller stopped using the specified singleuser image specified in our YAML config.

Also commented out all the extra volume stuff for preloaded files (for Roman).  We only have a volume for JWebbinar.