### PR TITLE
Fix image-scan already re-tagged

### DIFF
--- a/tools/image-scan-report
+++ b/tools/image-scan-report
@@ -40,28 +40,50 @@ FAIL_LEVELS = [
 ]
 
 
-def get_scan_results(image_digest):
+def run(cmd, cwd="."):
+    result = subprocess.run(
+        cmd.split(),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        check=True,
+	cwd=cwd,
+    )  # maybe succeeds
+    return result.stdout
+
+
+def _get_scan_results(image_digest, image_tag):
     """Issue an AWS command to dump the ECR scan results as JSON, load the
     JSON,  and return the resulting dict.
     """
     admin_arn=os.environ["ADMIN_ARN"]
     image_repo=os.environ["IMAGE_REPO"]
-    image_tag=os.environ["IMAGE_TAG"]
     ecr_account_to_use=os.environ["ECR_ACCOUNT_TO_USE"]
 
     image_id_arg = f"imageTag={image_tag}"
     if image_digest:
         image_id_arg = f"imageDigest={image_digest}"
 
-    print(f"Fetching ECR vulnerability scan for registry={ecr_account_to_use} repo={image_repo} tag={image_tag}",file=sys.stderr)
+    print(f"Fetching ECR vulnerability scan for registry={ecr_account_to_use} repo={image_repo} tag={image_tag}", file=sys.stderr)
 
-    scan_results = subprocess.check_output((
+    scan_results = run(
         f"awsudo -d 3600 {admin_arn}  aws ecr describe-image-scan-findings "
         f"--no-paginate "
         f"--registry-id {ecr_account_to_use} "
         f"--repository-name {image_repo} "
-        f"--image-id {image_id_arg}").split())
+        f"--image-id {image_id_arg}")
     return json.loads(scan_results)
+
+def get_scan_results(image_digest):
+    image_tag=os.environ["IMAGE_TAG"]
+    try:
+        return _get_scan_results(image_digest, image_tag)
+    except Exception:
+        print(f"Failed fetching {image_tag}.  Trying for approved tag.", file=sys.stderr)
+        if image_tag.startswith("unscanned-"):
+            return _get_scan_results(image_digest, image_tag[len("unscanned-"):])
+        else:
+            raise
 
 def limit_levels(version, levels, full_results):
     """Only keep findings with statuses in `levels`.  Assume `full_results` contains


### PR DESCRIPTION
Modified image-scan-report to handle the case where an image has been re-tagged by the time an attempt to fetch a report is made so the default image tag is no longer valid.
