### PR TITLE
Fix sscan-bandit missing some files

### DIFF
--- a/tools/sscan-bandit
+++ b/tools/sscan-bandit
@@ -4,7 +4,7 @@
 
 run_bandit() {
     # MEDIUM level and confidence,  or greater.
-    bandit -ll -ii --format txt  $*
+    bandit -v -ll -ii --format txt  $*
 }
 
 run_bandit `sscan-find-python-files`

--- a/tools/sscan-find-python-files
+++ b/tools/sscan-find-python-files
@@ -5,7 +5,7 @@
 DIRS=${1:-"deployments hub tools"}
 
 # Find Python she-bang scripts w/o .py extension
-find ${DIRS}  -type f | xargs grep -l -E '#!\s+/usr/bin/env\s+python'
+find ${DIRS}  -type f | xargs grep -l -E '#!\s*/usr/bin/env\s+python'
 
 # Find standard Python source code files
 find ${DIRS}  -name '*.py'

--- a/tools/sscan-npm-audit
+++ b/tools/sscan-npm-audit
@@ -1,0 +1,7 @@
+#! /bin/sh
+
+set -u
+
+level=${1:-high}
+
+image-exec npm audit --audit-level $level


### PR DESCRIPTION
sscan-find-python files was missing scripts using _#!/usr/bin/env python_ (no space after _#!_)
added -v to sscan-bandit to get more feedback on scanning.