### PR TITLE
Update existing docker-stacks clone

### DIFF
--- a/tools/image-base
+++ b/tools/image-base
@@ -19,8 +19,12 @@ docker build --progress plain --tag ubuntu-certs --file Dockerfile.certs.x \
 cd ~
 if [[ ! -d docker-stacks ]]; then
    git clone https://github.com/jupyter/docker-stacks.git
+   cd docker-stacks
+else
+    cd docker-stacks
+    git fetch origin
+    git rebase origin/master
 fi
-cd docker-stacks
 
 DARGS="--build-arg ROOT_CONTAINER=ubuntu-certs:latest" make build/base-notebook
 


### PR DESCRIPTION
 Modified image-base to update the docker-stacks clone if the directory already exists vs. randomly when there's a CI-node update.  We may need to pin a version but until we do this it shoots for "latest" without deleting an re-cloning docker-stacks completely.