### PR TITLE
Update base.yml to get jupyterlab > 3.1.4,  update frozen requirements.

### DIFF
--- a/deployments/common/image/base.yml
+++ b/deployments/common/image/base.yml
@@ -16,14 +16,14 @@ dependencies:
   - ipykernel
   - ipyevents
   # For Jupyter Desktop Proxy
-  - websockify==0.9.0
+  - websockify~=0.9.0
   - pip
   - pip:
-    - jupyterlab==3.1.0
+    - jupyterlab~=3.1.0
     - jupyter-server-proxy
     - nbgitpuller
     - ipyvuetify>=1.4.1
     - git+https://github.com/yuvipanda/jupyter-desktop-server
     # BELOW: these shouldn't need to be here...
-    - ipysplitpanes==0.1.0
-    - ipygoldenlayout==0.3.0
+    - ipysplitpanes~=0.1.0
+    - ipygoldenlayout~=0.3.0

--- a/deployments/jwebbinar/image/env-frozen/jdaviz/requirements.txt
+++ b/deployments/jwebbinar/image/env-frozen/jdaviz/requirements.txt
@@ -12,7 +12,7 @@ alembic==1.7.1
     # via jupyterhub
 ansiwrap==0.8.4
     # via papermill
-anyio==3.3.0
+anyio==3.3.1
     # via
     #   -r /opt/environments/jdaviz/jdaviz.pip
     #   jupyter-server
@@ -95,9 +95,9 @@ bokeh==2.3.3
     # via
     #   ipywidgets-bokeh
     #   jupyter-bokeh
-boto3==1.18.37
+boto3==1.18.38
     # via -r /opt/common-env/common.pip
-botocore==1.21.37
+botocore==1.21.38
     # via
     #   boto3
     #   s3transfer
@@ -207,7 +207,7 @@ freetype-py==2.2.0
     #   vispy
 fsspec==2021.8.1
     # via dask
-glue-astronomy==0.3
+glue-astronomy==0.3.1
     # via
     #   -r /opt/environments/jdaviz/jdaviz.pip
     #   jdaviz
@@ -270,7 +270,7 @@ ipygoldenlayout==0.4.0
     # via
     #   -r /opt/common-env/jupyter.pip
     #   jdaviz
-ipykernel==6.3.1
+ipykernel==6.4.0
     # via
     #   -r /opt/common-env/common.pip
     #   glue-core
@@ -398,7 +398,7 @@ jupyter-core==4.7.1
     #   nbformat
     #   notebook
     #   qtconsole
-jupyter-server==1.10.2
+jupyter-server==1.11.0
     # via
     #   -r /opt/common-env/jupyter.pip
     #   jupyter-server-proxy

--- a/deployments/jwebbinar/image/env-frozen/jwebbinar/requirements.txt
+++ b/deployments/jwebbinar/image/env-frozen/jwebbinar/requirements.txt
@@ -12,7 +12,7 @@ alembic==1.7.1
     # via jupyterhub
 ansiwrap==0.8.4
     # via papermill
-anyio==3.3.0
+anyio==3.3.1
     # via jupyter-server
 appdirs==1.4.4
     # via black
@@ -97,9 +97,9 @@ bokeh==2.3.3
     # via
     #   ipywidgets-bokeh
     #   jupyter-bokeh
-boto3==1.18.37
+boto3==1.18.38
     # via -r /opt/common-env/common.pip
-botocore==1.21.37
+botocore==1.21.38
     # via
     #   boto3
     #   s3transfer
@@ -235,7 +235,7 @@ ipyevents==2.0.1
     # via -r /opt/common-env/jupyter.pip
 ipygoldenlayout==0.4.0
     # via -r /opt/common-env/jupyter.pip
-ipykernel==6.3.1
+ipykernel==6.4.0
     # via
     #   -r /opt/common-env/common.pip
     #   glue-core
@@ -356,7 +356,7 @@ jupyter-core==4.7.1
     #   nbformat
     #   notebook
     #   qtconsole
-jupyter-server==1.10.2
+jupyter-server==1.11.0
     # via
     #   -r /opt/common-env/jupyter.pip
     #   jupyter-server-proxy

--- a/deployments/roman/image/env-frozen/cvt/requirements.txt
+++ b/deployments/roman/image/env-frozen/cvt/requirements.txt
@@ -12,7 +12,7 @@ alembic==1.7.1
     # via jupyterhub
 ansiwrap==0.8.4
     # via papermill
-anyio==3.3.0
+anyio==3.3.1
     # via jupyter-server
 appdirs==1.4.4
     # via black
@@ -52,9 +52,9 @@ bokeh==2.3.3
     # via
     #   ipywidgets-bokeh
     #   jupyter-bokeh
-boto3==1.18.37
+boto3==1.18.38
     # via -r /opt/common-env/common.pip
-botocore==1.21.37
+botocore==1.21.38
     # via
     #   boto3
     #   s3transfer
@@ -156,7 +156,7 @@ ipyevents==2.0.1
     # via -r /opt/common-env/jupyter.pip
 ipygoldenlayout==0.4.0
     # via -r /opt/common-env/jupyter.pip
-ipykernel==6.3.1
+ipykernel==6.4.0
     # via
     #   -r /opt/common-env/common.pip
     #   -r /opt/environments/cvt/cvt.pip
@@ -266,7 +266,7 @@ jupyter-core==4.7.1
     #   nbformat
     #   notebook
     #   qtconsole
-jupyter-server==1.10.2
+jupyter-server==1.11.0
     # via
     #   -r /opt/common-env/jupyter.pip
     #   jupyter-server-proxy

--- a/deployments/roman/image/env-frozen/roman-cal/requirements.txt
+++ b/deployments/roman/image/env-frozen/roman-cal/requirements.txt
@@ -12,7 +12,7 @@ alembic==1.7.1
     # via jupyterhub
 ansiwrap==0.8.4
     # via papermill
-anyio==3.3.0
+anyio==3.3.1
     # via jupyter-server
 appdirs==1.4.4
     # via black
@@ -101,9 +101,9 @@ bokeh==2.3.3
     #   -r /opt/environments/roman-cal/octarine.pip
     #   ipywidgets-bokeh
     #   jupyter-bokeh
-boto3==1.18.37
+boto3==1.18.38
     # via -r /opt/common-env/common.pip
-botocore==1.21.37
+botocore==1.21.38
     # via
     #   boto3
     #   s3transfer
@@ -242,7 +242,7 @@ ipyevents==2.0.1
     # via -r /opt/common-env/jupyter.pip
 ipygoldenlayout==0.4.0
     # via -r /opt/common-env/jupyter.pip
-ipykernel==6.3.1
+ipykernel==6.4.0
     # via
     #   -r /opt/common-env/common.pip
     #   glue-core
@@ -365,7 +365,7 @@ jupyter-core==4.7.1
     #   nbformat
     #   notebook
     #   qtconsole
-jupyter-server==1.10.2
+jupyter-server==1.11.0
     # via
     #   -r /opt/common-env/jupyter.pip
     #   jupyter-server-proxy

--- a/deployments/tike/image/env-frozen/tess/requirements.txt
+++ b/deployments/tike/image/env-frozen/tess/requirements.txt
@@ -37,7 +37,7 @@ allesfitter==1.2.4
     # via -r /opt/environments/tess/tess.pip
 ansiwrap==0.8.4
     # via papermill
-anyio==3.3.0
+anyio==3.3.1
     # via jupyter-server
 appdirs==1.4.4
     # via black
@@ -377,7 +377,7 @@ ipyevents==2.0.1
     # via -r /opt/common-env/jupyter.pip
 ipygoldenlayout==0.4.0
     # via -r /opt/common-env/jupyter.pip
-ipykernel==6.3.1
+ipykernel==6.4.0
     # via
     #   -r /opt/common-env/common.pip
     #   glue-core
@@ -507,7 +507,7 @@ jupyter-core==4.7.1
     #   nbformat
     #   notebook
     #   qtconsole
-jupyter-server==1.10.2
+jupyter-server==1.11.0
     # via
     #   -r /opt/common-env/jupyter.pip
     #   jupyter-server-proxy


### PR DESCRIPTION
The key change is base.yml,  and the absence of frozen requirements which show the concrete effect of the change points out lack of solid pinning of the base image.  Checking manually,  the base environment now gets jupyterlab==3.1.11 like the mission environments.