### PR TITLE
Fix image-graph-env

### DIFF
--- a/deployments/common/image/common-scripts/env-graph
+++ b/deployments/common/image/common-scripts/env-graph
@@ -1,0 +1,40 @@
+#! /bin/bash
+
+set -eu
+
+if [[ "$#" == "0" ]]; then
+    cat <<EOF
+usage:  env-graph  [-r] <environment> [pkg1 pkg2 ....]  > output_file.png
+
+Plot the dependency graph of the specified packages in conda <environment>.
+
+If -r is specified,  graph reverse dependencies.  Must be first parameter.
+
+If no packages are specified,  plot all pkgs in conda <environment>.
+
+e.g.  image-graph-env  tess  -r  s3fs boto3 botocore aiobotocore >s3fs.png
+      image-graph-env  tess  >all.png
+EOF
+    exit 1
+fi
+
+if [[ "$1" == "-r" ]]; then
+    reverse="-r"
+    shift
+else
+    reverse=""
+fi
+
+env=$1
+shift;
+
+pkgs=$*
+if [[ "$pkgs" != "" ]]; then
+    pkgs="-p `echo $pkgs | tr ' ' ',' `"
+fi
+
+/opt/common-scripts/env-run ${env} \
+       pip install graphviz  >& /dev/null
+
+/opt/common-scripts/env-run ${env} \
+       pipdeptree ${reverse} ${pkgs} --graph-output png

--- a/tools/image-graph-env
+++ b/tools/image-graph-env
@@ -2,37 +2,4 @@
 
 set -eu
 
-if [[ "$#" == "0" ]]; then
-    cat <<EOF
-usage:  image-graph-env  [-r] <environment> [pkg1 pkg2 ....]  > output_file.png
-
-Plot the dependency graph of the specified packages in conda <environment>.
-
-If -r is specified,  graph reverse dependencies.  Must be first parameter.
-
-If no packages are specified,  plot all pkgs in conda <environment>.
-
-e.g.  image-graph-env  tess  -r  s3fs boto3 botocore aiobotocore >s3fs.png
-      image-graph-env  tess  >all.png
-EOF
-    exit 1
-fi
-
-if [[ "$1" == "-r" ]]; then
-    reverse="-r"
-    shift
-else
-    reverse=""
-fi
-
-env=$1
-shift;
-
-pkgs=$*
-if [[ "$pkgs" != "" ]]; then
-    pkgs="-p `echo $pkgs | tr ' ' ',' `"
-fi
-
-image-exec \
-    /opt/common-scripts/env-run ${env} \
-         pipdeptree ${reverse} ${pkgs} --graph-output png
+image-exec  /opt/common-scripts/env-graph $*


### PR DESCRIPTION
Restored install of graphviz needed for image-graph-env dependency plotting
  by adding it dynamically for each plot.   It was removed due to package
  naming inconsistencies between conda and PyPi.