### PR TITLE
Improve Dockerfiles

### DIFF
--- a/deployments/roman/image/Dockerfile
+++ b/deployments/roman/image/Dockerfile
@@ -48,17 +48,17 @@ RUN cd /tmp && \
 # All specs for frozen builds need to be available before their normal installs
 USER ${NB_UID}
 
-COPY --chown=${NB_UID}:${NB_GID} env-frozen/  /opt/env-frozen/
-
 # ----------------------------------------------------------------------
 # Add jupyter-lab-extensions to base environment as well as standard packages.
 # Performing common update here enables mission specific frozen spec.
 
+COPY --chown=${NB_UID}:${NB_GID} env-frozen/base/  /opt/env-frozen/base/
 RUN   /opt/common-scripts/install-common  base
 
 # ------------------------------------------------------------------------------
 # CVT
 
+COPY --chown=${NB_UID}:${NB_GID} env-frozen/cvt/  /opt/env-frozen/cvt/
 COPY --chown=${NB_UID}:${NB_GID} environments/cvt/*.yml  /opt/environments/cvt/
 RUN /opt/common-scripts/env-conda cvt
 
@@ -72,6 +72,7 @@ COPY --chown=${NB_UID}:${NB_GID} environments/cvt/ /opt/environments/cvt/
 # ----------------------------------------------------------------------
 # Roman CAL
 
+COPY --chown=${NB_UID}:${NB_GID} env-frozen/roman-cal/  /opt/env-frozen/roman-cal/
 COPY --chown=${NB_UID}:${NB_GID} environments/roman-cal/*.yml  /opt/environments/roman-cal/
 RUN /opt/common-scripts/env-conda roman-cal
 
@@ -80,7 +81,7 @@ RUN /opt/common-scripts/env-compile roman-cal
 
 RUN /opt/common-scripts/env-sync roman-cal
 
-COPY --chown=${NB_UID}:${NB_GID} environments/roman-cal/ /opt/environments/
+COPY --chown=${NB_UID}:${NB_GID} environments/roman-cal/ /opt/environments/roman-cal/
 
 # ========================= ^^^^^ Custom  ^^^^^ =========================
 # ========================= vvvvv Generic vvvvv  =========================

--- a/deployments/roman/image/Dockerfile.custom
+++ b/deployments/roman/image/Dockerfile.custom
@@ -48,17 +48,17 @@ RUN cd /tmp && \
 # All specs for frozen builds need to be available before their normal installs
 USER ${NB_UID}
 
-COPY --chown=${NB_UID}:${NB_GID} env-frozen/  /opt/env-frozen/
-
 # ----------------------------------------------------------------------
 # Add jupyter-lab-extensions to base environment as well as standard packages.
 # Performing common update here enables mission specific frozen spec.
 
+COPY --chown=${NB_UID}:${NB_GID} env-frozen/base/  /opt/env-frozen/base/
 RUN   /opt/common-scripts/install-common  base
 
 # ------------------------------------------------------------------------------
 # CVT
 
+COPY --chown=${NB_UID}:${NB_GID} env-frozen/cvt/  /opt/env-frozen/cvt/
 COPY --chown=${NB_UID}:${NB_GID} environments/cvt/*.yml  /opt/environments/cvt/
 RUN /opt/common-scripts/env-conda cvt
 
@@ -72,6 +72,7 @@ COPY --chown=${NB_UID}:${NB_GID} environments/cvt/ /opt/environments/cvt/
 # ----------------------------------------------------------------------
 # Roman CAL
 
+COPY --chown=${NB_UID}:${NB_GID} env-frozen/roman-cal/  /opt/env-frozen/roman-cal/
 COPY --chown=${NB_UID}:${NB_GID} environments/roman-cal/*.yml  /opt/environments/roman-cal/
 RUN /opt/common-scripts/env-conda roman-cal
 
@@ -80,6 +81,6 @@ RUN /opt/common-scripts/env-compile roman-cal
 
 RUN /opt/common-scripts/env-sync roman-cal
 
-COPY --chown=${NB_UID}:${NB_GID} environments/roman-cal/ /opt/environments/
+COPY --chown=${NB_UID}:${NB_GID} environments/roman-cal/ /opt/environments/roman-cal/
 
 # ========================= ^^^^^ Custom  ^^^^^ =========================

--- a/deployments/tike/image/Dockerfile
+++ b/deployments/tike/image/Dockerfile
@@ -21,16 +21,16 @@ RUN curl --silent --show-error https://www.astro.princeton.edu/~jhartman/vartool
 
 USER ${NB_UID}
 
-COPY --chown=${NB_UID}:${NB_GID} env-frozen/ /opt/env-frozen/
-
 # ----------------------------------------------------------------------
 # Add jupyter-lab-extensions to base environment as well as standard packages.
 # Performing common update here enables mission specific frozen spec.
 
+COPY --chown=${NB_UID}:${NB_GID} env-frozen/base/  /opt/env-frozen/base/
 RUN   /opt/common-scripts/install-common  base
 
 # --------------------------- TESS -------------------------------------
 
+COPY --chown=${NB_UID}:${NB_GID} env-frozen/tess/  /opt/env-frozen/tess/
 COPY --chown=${NB_UID}:${NB_GID} environments/tess/*.yml /opt/environments/tess/
 RUN /opt/common-scripts/env-conda tess
 

--- a/deployments/tike/image/Dockerfile.custom
+++ b/deployments/tike/image/Dockerfile.custom
@@ -21,16 +21,16 @@ RUN curl --silent --show-error https://www.astro.princeton.edu/~jhartman/vartool
 
 USER ${NB_UID}
 
-COPY --chown=${NB_UID}:${NB_GID} env-frozen/ /opt/env-frozen/
-
 # ----------------------------------------------------------------------
 # Add jupyter-lab-extensions to base environment as well as standard packages.
 # Performing common update here enables mission specific frozen spec.
 
+COPY --chown=${NB_UID}:${NB_GID} env-frozen/base/  /opt/env-frozen/base/
 RUN   /opt/common-scripts/install-common  base
 
 # --------------------------- TESS -------------------------------------
 
+COPY --chown=${NB_UID}:${NB_GID} env-frozen/tess/  /opt/env-frozen/tess/
 COPY --chown=${NB_UID}:${NB_GID} environments/tess/*.yml /opt/environments/tess/
 RUN /opt/common-scripts/env-conda tess
 


### PR DESCRIPTION
 Improve roman and tike Dockerfiles by breaking the COPY of env-frozen  down into smaller sections which include only the files required to complete immediately following statements.   This eliminates a cache bust in the current implementation where any change in env-frozen forces the rebuild of most or all of the Dockerfile.  