### PR TITLE
Scheme for tag  controlled git-sync

### DIFF
--- a/deployments/common/image/Dockerfile
+++ b/deployments/common/image/Dockerfile
@@ -18,7 +18,7 @@ ENV CONDA_DIR=/opt/conda
 ENV SHELL=/bin/bash
 ENV PATH=${CONDA_DIR}/bin:${PATH}
 ENV CFLAGS="-fcommon"
-ENV JUPYTERHUB_CONTENT_TAG=main
+ENV JH_CONTENT_VERSION=main
 
 # ------------------------------------------------------------------------
 USER root

--- a/deployments/common/image/Dockerfile
+++ b/deployments/common/image/Dockerfile
@@ -18,6 +18,7 @@ ENV CONDA_DIR=/opt/conda
 ENV SHELL=/bin/bash
 ENV PATH=${CONDA_DIR}/bin:${PATH}
 ENV CFLAGS="-fcommon"
+ENV JUPYTERHUB_CONTENT_TAG=main
 
 # ------------------------------------------------------------------------
 USER root

--- a/deployments/tike/config/prod.yaml
+++ b/deployments/tike/config/prod.yaml
@@ -2,6 +2,8 @@ jupyterhub:
   singleuser:
     image:
       tag: latest-prod
+    extraEnv:
+      JUPYTERHUB_CONTENT_TAG: jupyterhub-tike-ops
   prePuller:
     continuous:
       enabled: true

--- a/deployments/tike/config/prod.yaml
+++ b/deployments/tike/config/prod.yaml
@@ -3,7 +3,7 @@ jupyterhub:
     image:
       tag: latest-prod
     extraEnv:
-      JUPYTERHUB_CONTENT_TAG: jupyterhub-tike-ops
+      JH_CONTENT_VERSION: jupyterhub-tike-ops
   prePuller:
     continuous:
       enabled: true

--- a/deployments/tike/image/env-frozen/tess/requirements.txt
+++ b/deployments/tike/image/env-frozen/tess/requirements.txt
@@ -205,7 +205,7 @@ cloudpickle==2.0.0
     #   distributed
 colour==0.1.5
     # via pixiedust
-configparser==5.1.0
+configparser==5.0.2
     # via transitleastsquares
 corner==2.2.1
     # via
@@ -329,7 +329,7 @@ glue-jupyter==0.10.1
     #   -r /opt/environments/tess/jupyter.pip
 glue-vispy-viewers==1.0.5
     # via glue-jupyter
-google-auth==1.35.0
+google-auth==2.3.3
     # via
     #   google-auth-oauthlib
     #   tensorboard
@@ -373,9 +373,7 @@ importlib-metadata==4.8.1
     #   alembic
     #   keyring
 importlib-resources==5.4.0
-    # via
-    #   alembic
-    #   jsonschema
+    # via alembic
 iniconfig==1.1.1
     # via pytest
 intel-cmplr-lib-rt==2021.4.0
@@ -518,7 +516,7 @@ jplephem==2.16
     # via astrobase
 json5==0.9.6
     # via jupyterlab-server
-jsonschema==4.2.0
+jsonschema==4.1.2
     # via
     #   jupyter-telemetry
     #   jupyterlab-server
@@ -895,7 +893,7 @@ prometheus-client==0.12.0
     #   jupyter-server
     #   jupyterhub
     #   notebook
-prompt-toolkit==3.0.22
+prompt-toolkit==3.0.21
     # via ipython
 protobuf==3.19.1
     # via
@@ -911,7 +909,7 @@ ptyprocess==0.7.0
     # via
     #   pexpect
     #   terminado
-py==1.11.0
+py==1.10.0
     # via pytest
 pyasn1==0.4.8
     # via
@@ -1215,7 +1213,7 @@ tblib==1.7.0
     # via distributed
 tenacity==8.0.1
     # via papermill
-tensorboard==2.6.0
+tensorboard==2.7.0
     # via
     #   -r /opt/environments/tess/ml.pip
     #   tensorflow
@@ -1223,7 +1221,7 @@ tensorboard-data-server==0.6.1
     # via tensorboard
 tensorboard-plugin-wit==1.8.0
     # via tensorboard
-tensorflow==2.6.2
+tensorflow==2.6.1
     # via -r /opt/environments/tess/ml.pip
 tensorflow-estimator==2.6.0
     # via

--- a/deployments/tike/image/env-frozen/tess/requirements.txt
+++ b/deployments/tike/image/env-frozen/tess/requirements.txt
@@ -205,7 +205,7 @@ cloudpickle==2.0.0
     #   distributed
 colour==0.1.5
     # via pixiedust
-configparser==5.0.2
+configparser==5.1.0
     # via transitleastsquares
 corner==2.2.1
     # via
@@ -329,7 +329,7 @@ glue-jupyter==0.10.1
     #   -r /opt/environments/tess/jupyter.pip
 glue-vispy-viewers==1.0.5
     # via glue-jupyter
-google-auth==2.3.3
+google-auth==1.35.0
     # via
     #   google-auth-oauthlib
     #   tensorboard
@@ -373,7 +373,9 @@ importlib-metadata==4.8.1
     #   alembic
     #   keyring
 importlib-resources==5.4.0
-    # via alembic
+    # via
+    #   alembic
+    #   jsonschema
 iniconfig==1.1.1
     # via pytest
 intel-cmplr-lib-rt==2021.4.0
@@ -516,7 +518,7 @@ jplephem==2.16
     # via astrobase
 json5==0.9.6
     # via jupyterlab-server
-jsonschema==4.1.2
+jsonschema==4.2.0
     # via
     #   jupyter-telemetry
     #   jupyterlab-server
@@ -893,7 +895,7 @@ prometheus-client==0.12.0
     #   jupyter-server
     #   jupyterhub
     #   notebook
-prompt-toolkit==3.0.21
+prompt-toolkit==3.0.22
     # via ipython
 protobuf==3.19.1
     # via
@@ -909,7 +911,7 @@ ptyprocess==0.7.0
     # via
     #   pexpect
     #   terminado
-py==1.10.0
+py==1.11.0
     # via pytest
 pyasn1==0.4.8
     # via
@@ -1213,7 +1215,7 @@ tblib==1.7.0
     # via distributed
 tenacity==8.0.1
     # via papermill
-tensorboard==2.7.0
+tensorboard==2.6.0
     # via
     #   -r /opt/environments/tess/ml.pip
     #   tensorflow
@@ -1221,7 +1223,7 @@ tensorboard-data-server==0.6.1
     # via tensorboard
 tensorboard-plugin-wit==1.8.0
     # via tensorboard
-tensorflow==2.6.1
+tensorflow==2.6.2
     # via -r /opt/environments/tess/ml.pip
 tensorflow-estimator==2.6.0
     # via

--- a/deployments/tike/image/environments/post-start-hook
+++ b/deployments/tike/image/environments/post-start-hook
@@ -26,7 +26,7 @@ rsync -r  /etc/default-home-contents/ /home/jovyan
 # .............................................................................................
 
 TC=/home/jovyan/tike_content
-/opt/common-scripts/git-sync  https://github.com/spacetelescope/tike_content.git  $JUPYTERHUB_CONTENT_TAG  $TC
+/opt/common-scripts/git-sync  https://github.com/spacetelescope/tike_content.git  $JH_CONTENT_VERSION  $TC
 
 SN=/home/jovyan/spacetelescope-notebooks
 /opt/common-scripts/git-sync   https://github.com/spacetelescope/notebooks.git   master   ${SN}

--- a/deployments/tike/image/environments/post-start-hook
+++ b/deployments/tike/image/environments/post-start-hook
@@ -26,7 +26,7 @@ rsync -r  /etc/default-home-contents/ /home/jovyan
 # .............................................................................................
 
 TC=/home/jovyan/tike_content
-/opt/common-scripts/git-sync  https://github.com/spacetelescope/tike_content.git  main  $TC
+/opt/common-scripts/git-sync  https://github.com/spacetelescope/tike_content.git  $JUPYTERHUB_CONTENT_TAG  $TC
 
 SN=/home/jovyan/spacetelescope-notebooks
 /opt/common-scripts/git-sync   https://github.com/spacetelescope/notebooks.git   master   ${SN}
@@ -117,8 +117,6 @@ EOF
 
 # .............................................................................................
 
-# /opt/common-scripts/set-notebook-kernel tess 'TESS' `cat /opt/environments/tess/tests/notebooks`
-# /opt/common-scripts/set-notebook-kernel tess 'TESS' `cat /opt/environments/tess/tests/notebooks-failing`
+# /opt/common-scripts/set-notebook-kernel tess `cat /opt/environments/tess/tests/notebooks`
+# /opt/common-scripts/set-notebook-kernel tess `cat /opt/environments/tess/tests/notebooks-failing`
 
-# /opt/common-scripts/set-notebook-kernel tess 'TESS' `cat /opt/environments/tess/tests/long-notebooks`
-# /opt/common-scripts/set-notebook-kernel tess 'TESS' `cat /opt/environments/tess/tests/long-notebooks-failing`


### PR DESCRIPTION
 Added JUPYTERHUB_CONTENT_TAG env var used to define SDLC-specific values for content repo tags like jupyterhub-tike-ops.   
By default all images set JUPYTERHUB_CONTENT_TAG=main.   
For Tike OPS,  the override JUPYTERHUB_CONTENT_TAG=jupyter-tike-ops is set using the PROD config yaml.
The post-start-hook script git-sync's tike_content relative to $JUPYTERHUB_CONTENT_TAG.   Thus for the Tike DEV and TEST strings git-sync pulls down the "main" branch,  but for OPS git-sync pulls down the jupyterhub-tike-ops tag.   Thus by changing the jupyterhub-tike-ops tag on the tike_content repo the version of content synced to OPS can be controlled.   In particular DEV and TEST can be used to test out new content prior to publishing it to OPS via changing the tag.