### PR TITLE
Variable branch git-sync support

### DIFF
--- a/deployments/common/image/Dockerfile
+++ b/deployments/common/image/Dockerfile
@@ -18,6 +18,7 @@ ENV CONDA_DIR=/opt/conda
 ENV SHELL=/bin/bash
 ENV PATH=${CONDA_DIR}/bin:${PATH}
 ENV CFLAGS="-fcommon"
+ENV JH_CONTENT_VERSION=main
 
 # ------------------------------------------------------------------------
 USER root

--- a/deployments/tike/config/prod.yaml
+++ b/deployments/tike/config/prod.yaml
@@ -2,6 +2,8 @@ jupyterhub:
   singleuser:
     image:
       tag: latest-prod
+    extraEnv:
+      JH_CONTENT_VERSION: jupyterhub-tike-ops
   prePuller:
     continuous:
       enabled: true

--- a/deployments/tike/image/environments/post-start-hook
+++ b/deployments/tike/image/environments/post-start-hook
@@ -26,7 +26,7 @@ rsync -r  /etc/default-home-contents/ /home/jovyan
 # .............................................................................................
 
 TC=/home/jovyan/tike_content
-/opt/common-scripts/git-sync  https://github.com/spacetelescope/tike_content.git  main  $TC
+/opt/common-scripts/git-sync  https://github.com/spacetelescope/tike_content.git  $JH_CONTENT_VERSION  $TC
 
 SN=/home/jovyan/spacetelescope-notebooks
 /opt/common-scripts/git-sync   https://github.com/spacetelescope/notebooks.git   master   ${SN}
@@ -117,8 +117,6 @@ EOF
 
 # .............................................................................................
 
-# /opt/common-scripts/set-notebook-kernel tess 'TESS' `cat /opt/environments/tess/tests/notebooks`
-# /opt/common-scripts/set-notebook-kernel tess 'TESS' `cat /opt/environments/tess/tests/notebooks-failing`
+# /opt/common-scripts/set-notebook-kernel tess `cat /opt/environments/tess/tests/notebooks`
+# /opt/common-scripts/set-notebook-kernel tess `cat /opt/environments/tess/tests/notebooks-failing`
 
-# /opt/common-scripts/set-notebook-kernel tess 'TESS' `cat /opt/environments/tess/tests/long-notebooks`
-# /opt/common-scripts/set-notebook-kernel tess 'TESS' `cat /opt/environments/tess/tests/long-notebooks-failing`


### PR DESCRIPTION
Added JH_CONTENT_VERSION env var used to define SDLC-specific values
  for content repo tags.
Defaults JH_CONTENT_VERSION=main in common Dockerfile.
JupyterHub YAML config like tike/config/prod.yaml overrides env var
  at runtime to something like jupyterhub-tike-ops.
Calls to git-sync in the container sync relative to $JH_CONTENT_VERSION
  if desired or continue to hard-code branch as they used to.