### PR TITLE
Add check_cluster.py EKS and Hub health check script.

### DIFF
--- a/infrequent-env
+++ b/infrequent-env
@@ -5,6 +5,11 @@ export PATH="`pwd`/tools":${PATH}
 # ----------------- vvvv less frequently changed inputs vvvv -------------------------------
 #
 
+export JH_HOSTNAME="${DEPLOYMENT_NAME}.science.stsci.edu"
+if [[ "$ENVIRONMENT" != "prod" ]]; then
+    export JH_HOSTNAME="${ENVIRONMENT}.${JH_HOSTNAME}"
+fi
+
 # Select "conda" tool used to install conda package and environments: conda or mamba
 #   mamba is largely a drop-in replacement for mamba with improved dependency resolution,
 #   parallel downloads, and C++ implementation.

--- a/tools/check_cluster.inputs
+++ b/tools/check_cluster.inputs
@@ -1,0 +1,224 @@
+EFS File Systems: "- CreationTime: '2021-10-20T16:42:00+00:00'\n  CreationToken: terraform-20211020164200767000000001\n\
+  \  Encrypted: true\n  FileSystemArn: arn:aws:elasticfilesystem:us-east-1:194502879724:file-system/fs-03fa5e42b828faae1\n\
+  \  FileSystemId: fs-03fa5e42b828faae1\n  KmsKeyId: arn:aws:kms:us-east-1:194502879724:key/7d6055fe-d84e-48c3-aa46-37697c9eeed2\n\
+  \  LifeCycleState: available\n  Name: roman-home-dirs\n  NumberOfMountTargets: 3\n\
+  \  OwnerId: '194502879724'\n  PerformanceMode: generalPurpose\n  SizeInBytes:\n\
+  \    Timestamp: '2021-11-23T18:37:35+00:00'\n    Value: 5478400\n    ValueInIA:\
+  \ 0\n    ValueInStandard: 5478400\n  Tags:\n  - Key: Name\n    Value: roman-home-dirs\n\
+  \  - Key: stsci-backup\n    Value: dmd-2w-sat\n  ThroughputMode: bursting\n- CreationTime:\
+  \ '2021-05-13T15:54:17+00:00'\n  CreationToken: efscinode-I9FLO5JlkF1M\n  Encrypted:\
+  \ true\n  FileSystemArn: arn:aws:elasticfilesystem:us-east-1:194502879724:file-system/fs-4ea508fa\n\
+  \  FileSystemId: fs-4ea508fa\n  KmsKeyId: arn:aws:kms:us-east-1:194502879724:key/7d6055fe-d84e-48c3-aa46-37697c9eeed2\n\
+  \  LifeCycleState: available\n  Name: ci-node\n  NumberOfMountTargets: 3\n  OwnerId:\
+  \ '194502879724'\n  PerformanceMode: generalPurpose\n  SizeInBytes:\n    Timestamp:\
+  \ '2021-11-23T18:34:12+00:00'\n    Value: 681562112\n    ValueInIA: 0\n    ValueInStandard:\
+  \ 681562112\n  Tags:\n  - Key: Name\n    Value: ci-node\n  ThroughputMode: bursting"
+EKS Deployments: 'NAMESPACE     NAME                                        READY   UP-TO-DATE   AVAILABLE   AGE
+
+  datadog       datadog-cluster-agent                       1/1     1            1           20d
+
+  datadog       datadog-kube-state-metrics                  1/1     1            1           20d
+
+  default       hub                                         1/1     1            1           12d
+
+  default       proxy                                       1/1     1            1           12d
+
+  default       user-scheduler                              2/2     2            2           12d
+
+  kube-system   cluster-autoscaler-aws-cluster-autoscaler   1/1     1            1           21d
+
+  kube-system   coredns                                     2/2     2            2           21d
+
+  support       roman-efs-provisioner                       1/1     1            1           21d'
+EKS Services: 'NAMESPACE     NAME                                        TYPE           CLUSTER-IP       EXTERNAL-IP                                                              PORT(S)                      AGE
+
+  datadog       datadog-cluster-agent                       ClusterIP      172.20.117.67    <none>                                                                   5005/TCP                     20d
+
+  datadog       datadog-kube-state-metrics                  ClusterIP      172.20.177.159   <none>                                                                   8080/TCP                     20d
+
+  default       hub                                         ClusterIP      172.20.22.23     <none>                                                                   8081/TCP                     12d
+
+  default       kubernetes                                  ClusterIP      172.20.0.1       <none>                                                                   443/TCP                      21d
+
+  default       proxy-api                                   ClusterIP      172.20.52.136    <none>                                                                   8001/TCP                     12d
+
+  default       proxy-public                                LoadBalancer   172.20.45.166    a88c6fb16565a4f3cabb538289a94a31-360641126.us-east-1.elb.amazonaws.com   443:31955/TCP,80:32311/TCP   12d
+
+  kube-system   cluster-autoscaler-aws-cluster-autoscaler   ClusterIP      172.20.12.70     <none>                                                                   8085/TCP                     21d
+
+  kube-system   kube-dns                                    ClusterIP      172.20.0.10      <none>                                                                   53/UDP,53/TCP                21d'
+JupyterHub Index Page: "--2021-11-23 18:53:20--  http://test.roman.science.stsci.edu/\n\
+  Resolving test.roman.science.stsci.edu (test.roman.science.stsci.edu)... 52.55.198.220,\
+  \ 34.235.194.72, 52.22.162.227\nConnecting to test.roman.science.stsci.edu (test.roman.science.stsci.edu)|52.55.198.220|:80...\
+  \ connected.\nHTTP request sent, awaiting response... 301 Moved Permanently\nLocation:\
+  \ https://test.roman.science.stsci.edu:443/ [following]\n--2021-11-23 18:53:20--\
+  \  https://test.roman.science.stsci.edu/\nConnecting to test.roman.science.stsci.edu\
+  \ (test.roman.science.stsci.edu)|52.55.198.220|:443... connected.\nWARNING: cannot\
+  \ verify test.roman.science.stsci.edu's certificate, issued by \u2018/C=US/ST=MI/L=Ann\
+  \ Arbor/O=Internet2/OU=InCommon/CN=InCommon RSA Server CA\u2019:\n  Unable to locally\
+  \ verify the issuer's authority.\nHTTP request sent, awaiting response... 302 Found\n\
+  Location: /hub/ [following]\n--2021-11-23 18:53:20--  https://test.roman.science.stsci.edu/hub/\n\
+  Connecting to test.roman.science.stsci.edu (test.roman.science.stsci.edu)|52.55.198.220|:443...\
+  \ connected.\nWARNING: cannot verify test.roman.science.stsci.edu's certificate,\
+  \ issued by \u2018/C=US/ST=MI/L=Ann Arbor/O=Internet2/OU=InCommon/CN=InCommon RSA\
+  \ Server CA\u2019:\n  Unable to locally verify the issuer's authority.\nHTTP request\
+  \ sent, awaiting response... 302 Found\nLocation: /hub/login?next=%2Fhub%2F [following]\n\
+  --2021-11-23 18:53:20--  https://test.roman.science.stsci.edu/hub/login?next=%2Fhub%2F\n\
+  Connecting to test.roman.science.stsci.edu (test.roman.science.stsci.edu)|52.55.198.220|:443...\
+  \ connected.\nWARNING: cannot verify test.roman.science.stsci.edu's certificate,\
+  \ issued by \u2018/C=US/ST=MI/L=Ann Arbor/O=Internet2/OU=InCommon/CN=InCommon RSA\
+  \ Server CA\u2019:\n  Unable to locally verify the issuer's authority.\nHTTP request\
+  \ sent, awaiting response... 200 OK\nLength: 4483 (4.4K) [text/html]\nSaving to:\
+  \ \u2018STDOUT\u2019\n\n\n\n<!DOCTYPE HTML>\n<html>\n\n<head>\n    <meta charset=\"\
+  utf-8\">\n\n    <title>JupyterHub</title>\n    <meta http-equiv=\"X-UA-Compatible\"\
+  \ content=\"chrome=1\">\n    <meta name=\"viewport\" content=\"width=device-width,\
+  \ initial-scale=1.0\">\n\n    \n    <link rel=\"stylesheet\" href=\"/hub/static/css/style.min.css?v=a690a7f26f8eda24b6043d972eda379b7f3df65dcb4832fbec0d72d1585b6bdf2bd15c7f3ec4597b79a7c91798181ba23b9a0204da8165b21ff81cd85f89a933\"\
+  \ type=\"text/css\"/>\n    \n    \n    <link rel=\"icon\" href=\"/hub/static/favicon.ico?v=fde5757cd3892b979919d3b1faa88a410f28829feb5ba22b6cf069f2c6c98675fceef90f932e49b510e74d65c681d5846b943e7f7cc1b41867422f0481085c1f\"\
+  \ type=\"image/x-icon\">\n    \n    \n    <script src=\"/hub/static/components/requirejs/require.js?v=bd1aa102bdb0b27fbf712b32cfcd29b016c272acf3d864ee8469376eaddd032cadcf827ff17c05a8c8e20061418fe58cf79947049f5c0dff3b4f73fcc8cad8ec\"\
+  \ type=\"text/javascript\" charset=\"utf-8\"></script>\n    <script src=\"/hub/static/components/jquery/dist/jquery.min.js?v=6cb4f4426f559c06190df97229c05a436820d21498350ac9f118a5625758435171418a022ed523bae46e668f9f8ea871feab6aff58ad2740b67a30f196d65516\"\
+  \ type=\"text/javascript\" charset=\"utf-8\"></script>\n    <script src=\"/hub/static/components/bootstrap/dist/js/bootstrap.min.js?v=a014e9acc78d10a0a7a9fbaa29deac6ef17398542d9574b77b40bf446155d210fa43384757e3837da41b025998ebfab4b9b6f094033f9c226392b800df068bce\"\
+  \ type=\"text/javascript\" charset=\"utf-8\"></script>\n    \n    <script>\n   \
+  \   require.config({\n          \n          urlArgs: \"v=20211122100807\",\n   \
+  \       \n          baseUrl: '/hub/static/js',\n          paths: {\n           \
+  \ components: '../components',\n            jquery: '../components/jquery/dist/jquery.min',\n\
+  \            bootstrap: '../components/bootstrap/dist/js/bootstrap.min',\n     \
+  \       moment: \"../components/moment/moment\",\n          },\n          shim:\
+  \ {\n            bootstrap: {\n              deps: [\"jquery\"],\n             \
+  \ exports: \"bootstrap\"\n            },\n          }\n      });\n    </script>\n\
+  \n    <script type=\"text/javascript\">\n      window.jhdata = {\n        base_url:\
+  \ \"/hub/\",\n        prefix: \"/\",\n        \n        \n        admin_access:\
+  \ false,\n        \n        \n        options_form: false,\n        \n      }\n\
+  \    </script>\n\n    \n    \n\n</head>\n\n<body>\n\n<noscript>\n  <div id='noscript'>\n\
+  \    JupyterHub requires JavaScript.<br>\n    Please enable it to proceed.\n  </div>\n\
+  </noscript>\n\n\n  <nav class=\"navbar navbar-default\">\n    <div class=\"container-fluid\"\
+  >\n      <div class=\"navbar-header\">\n        \n        <span id=\"jupyterhub-logo\"\
+  \ class=\"pull-left\">\n            <a href=\"/hub/\"><img src='/hub/logo' alt='JupyterHub'\
+  \ class='jpy-logo' title='Home'/></a>\n        </span>\n        \n        \n   \
+  \   </div>\n\n      <div class=\"collapse navbar-collapse\" id=\"thenavbar\">\n\
+  \        \n        <ul class=\"nav navbar-nav navbar-right\">\n          \n    \
+  \        <li>\n              \n\n            </li>\n          \n        </ul>\n\
+  \      </div>\n\n      \n      \n    </div>\n  </nav>\n\n\n\n\n\n\n\n\n\n\n\n<div\
+  \ id=\"login-main\" class=\"container\">\n\n<div class=\"service-login\">\n  <a\
+  \ role=\"button\" class='btn btn-jupyter btn-lg' href='/hub/oauth_login?next=%2Fhub%2F'>\n\
+  \    Sign in with MAST\n  </a>\n</div>\n\n</div>\n\n\n\n\n\n\n\n\n\n\n<div class=\"\
+  modal fade\" id=\"error-dialog\" tabindex=\"-1\" role=\"dialog\" aria-labelledby=\"\
+  error-label\" aria-hidden=\"true\">\n  <div class=\"modal-dialog\">\n    <div class=\"\
+  modal-content\">\n      <div class=\"modal-header\">\n        <button type=\"button\"\
+  \ class=\"close\" data-dismiss=\"modal\"><span aria-hidden=\"true\">&times;</span><span\
+  \ class=\"sr-only\">Close</span></button>\n        <h4 class=\"modal-title\" id=\"\
+  error-label\">Error</h4>\n      </div>\n      <div class=\"modal-body\">\n     \
+  \   \n  <div class=\"ajax-error\">\n    The error\n  </div>\n\n      </div>\n  \
+  \    <div class=\"modal-footer\">\n        <button type=\"button\" class=\"btn btn-default\"\
+  \ data-dismiss=\"modal\">Cancel</button>\n        <button type=\"button\" class=\"\
+  btn btn-primary\" data-dismiss=\"modal\" data-dismiss=\"modal\">OK</button>\n  \
+  \    </div>\n    </div>\n  </div>\n</div>\n\n\n\n\n\n<script>\nif (window.location.protocol\
+  \ === \"http:\") {\n  // unhide http warning\n  var warning = document.getElementById('insecure-login-warning');\n\
+  \  warning.className = warning.className.replace(/\\bhidden\\b/, '');\n}\n// setup\
+  \ onSubmit feedback\n$('form').submit((e) => {\n  var form = $(e.target);\n  form.find('.feedback-container>input').attr('disabled',\
+  \ true);\n  form.find('.feedback-container>*').toggleClass('hidden');\n  form.find('.feedback-widget>*').toggleClass('fa-pulse');\n\
+  });\n</script>\n\n\n</body>\n\n</html>\n     0K ....                           \
+  \                       100%  839M=0s\n\n2021-11-23 18:53:20 (839 MB/s) - written\
+  \ to stdout [4483/4483]"
+JupyterHub Nodes: 'NAME                            STATUS   ROLES    AGE   VERSION               LABELS
+
+  ip-10-146-25-64.ec2.internal    Ready    <none>   32h   v1.21.5-eks-bc4871b   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=t3.small,beta.kubernetes.io/os=linux,eks.amazonaws.com/capacityType=ON_DEMAND,eks.amazonaws.com/nodegroup-image=ami-06200bac1d3b301da,eks.amazonaws.com/nodegroup=roman-core-impala-jittery,eks.amazonaws.com/sourceLaunchTemplateId=lt-06dfb7cf86479f1c5,eks.amazonaws.com/sourceLaunchTemplateVersion=1,failure-domain.beta.kubernetes.io/region=us-east-1,failure-domain.beta.kubernetes.io/zone=us-east-1a,hub.jupyter.org/node-purpose=core,kubernetes.io/arch=amd64,kubernetes.io/hostname=ip-10-146-25-64.ec2.internal,kubernetes.io/os=linux,node.kubernetes.io/instance-type=t3.small,topology.kubernetes.io/region=us-east-1,topology.kubernetes.io/zone=us-east-1a
+
+  ip-10-146-26-17.ec2.internal    Ready    <none>   32h   v1.21.5-eks-bc4871b   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=t3.small,beta.kubernetes.io/os=linux,eks.amazonaws.com/capacityType=ON_DEMAND,eks.amazonaws.com/nodegroup-image=ami-06200bac1d3b301da,eks.amazonaws.com/nodegroup=roman-core-impala-jittery,eks.amazonaws.com/sourceLaunchTemplateId=lt-06dfb7cf86479f1c5,eks.amazonaws.com/sourceLaunchTemplateVersion=1,failure-domain.beta.kubernetes.io/region=us-east-1,failure-domain.beta.kubernetes.io/zone=us-east-1c,hub.jupyter.org/node-purpose=core,kubernetes.io/arch=amd64,kubernetes.io/hostname=ip-10-146-26-17.ec2.internal,kubernetes.io/os=linux,node.kubernetes.io/instance-type=t3.small,topology.kubernetes.io/region=us-east-1,topology.kubernetes.io/zone=us-east-1c
+
+  ip-10-147-25-213.ec2.internal   Ready    <none>   32h   v1.21.5-eks-bc4871b   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=t3.small,beta.kubernetes.io/os=linux,eks.amazonaws.com/capacityType=ON_DEMAND,eks.amazonaws.com/nodegroup-image=ami-06200bac1d3b301da,eks.amazonaws.com/nodegroup=roman-core-impala-jittery,eks.amazonaws.com/sourceLaunchTemplateId=lt-06dfb7cf86479f1c5,eks.amazonaws.com/sourceLaunchTemplateVersion=1,failure-domain.beta.kubernetes.io/region=us-east-1,failure-domain.beta.kubernetes.io/zone=us-east-1b,hub.jupyter.org/node-purpose=core,kubernetes.io/arch=amd64,kubernetes.io/hostname=ip-10-147-25-213.ec2.internal,kubernetes.io/os=linux,node.kubernetes.io/instance-type=t3.small,topology.kubernetes.io/region=us-east-1,topology.kubernetes.io/zone=us-east-1b
+
+  ip-10-147-25-56.ec2.internal    Ready    <none>   32h   v1.21.5-eks-bc4871b   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=r5.xlarge,beta.kubernetes.io/os=linux,eks.amazonaws.com/capacityType=ON_DEMAND,eks.amazonaws.com/nodegroup-image=ami-06200bac1d3b301da,eks.amazonaws.com/nodegroup=roman-notebook-giraffe-talented,eks.amazonaws.com/sourceLaunchTemplateId=lt-0b2b9c74b91a71bef,eks.amazonaws.com/sourceLaunchTemplateVersion=1,failure-domain.beta.kubernetes.io/region=us-east-1,failure-domain.beta.kubernetes.io/zone=us-east-1b,hub.jupyter.org/node-purpose=user,kubernetes.io/arch=amd64,kubernetes.io/hostname=ip-10-147-25-56.ec2.internal,kubernetes.io/os=linux,node.kubernetes.io/instance-type=r5.xlarge,topology.kubernetes.io/region=us-east-1,topology.kubernetes.io/zone=us-east-1b'
+JupyterHub Pods: 'NAMESPACE     NAME                                                         READY   STATUS    RESTARTS   AGE   IP              NODE                            NOMINATED
+  NODE   READINESS GATES
+
+  datadog       datadog-cluster-agent-55477fc58b-66tqt                       1/1     Running   0          32h   10.147.25.95    ip-10-147-25-56.ec2.internal    <none>           <none>
+
+  datadog       datadog-kube-state-metrics-6fb56bf889-9ww67                  1/1     Running   0          32h   10.147.25.249   ip-10-147-25-56.ec2.internal    <none>           <none>
+
+  default       continuous-image-puller-mzng6                                1/1     Running   0          32h   10.147.25.97    ip-10-147-25-56.ec2.internal    <none>           <none>
+
+  default       hub-57ffd9747c-nb8fz                                         1/1     Running   0          32h   10.146.25.92    ip-10-146-25-64.ec2.internal    <none>           <none>
+
+  default       proxy-58bdccdb98-gc64g                                       1/1     Running   0          32h   10.147.25.217   ip-10-147-25-213.ec2.internal   <none>           <none>
+
+  default       user-placeholder-0                                           1/1     Running   0          32h   10.147.25.144   ip-10-147-25-56.ec2.internal    <none>           <none>
+
+  default       user-scheduler-c5fbd6b8d-fflns                               1/1     Running   0          32h   10.146.26.94    ip-10-146-26-17.ec2.internal    <none>           <none>
+
+  default       user-scheduler-c5fbd6b8d-zk2gg                               1/1     Running   0          32h   10.146.25.9     ip-10-146-25-64.ec2.internal    <none>           <none>
+
+  kube-system   aws-node-2jzpb                                               1/1     Running   0          32h   10.147.25.56    ip-10-147-25-56.ec2.internal    <none>           <none>
+
+  kube-system   aws-node-h47m8                                               1/1     Running   0          32h   10.146.26.17    ip-10-146-26-17.ec2.internal    <none>           <none>
+
+  kube-system   aws-node-jxk7j                                               1/1     Running   0          32h   10.146.25.64    ip-10-146-25-64.ec2.internal    <none>           <none>
+
+  kube-system   aws-node-twbnx                                               1/1     Running   0          32h   10.147.25.213   ip-10-147-25-213.ec2.internal   <none>           <none>
+
+  kube-system   cluster-autoscaler-aws-cluster-autoscaler-7d85444d49-wzxkm   1/1     Running   0          32h   10.147.25.169   ip-10-147-25-56.ec2.internal    <none>           <none>
+
+  kube-system   coredns-66cb55d4f4-9dwmp                                     1/1     Running   0          32h   10.147.25.45    ip-10-147-25-56.ec2.internal    <none>           <none>
+
+  kube-system   coredns-66cb55d4f4-nnthm                                     1/1     Running   0          32h   10.146.26.66    ip-10-146-26-17.ec2.internal    <none>           <none>
+
+  kube-system   kube-proxy-9fdx7                                             1/1     Running   0          32h   10.146.25.64    ip-10-146-25-64.ec2.internal    <none>           <none>
+
+  kube-system   kube-proxy-kkwl5                                             1/1     Running   0          32h   10.147.25.213   ip-10-147-25-213.ec2.internal   <none>           <none>
+
+  kube-system   kube-proxy-l2vzn                                             1/1     Running   0          32h   10.147.25.56    ip-10-147-25-56.ec2.internal    <none>           <none>
+
+  kube-system   kube-proxy-vd58l                                             1/1     Running   0          32h   10.146.26.17    ip-10-146-26-17.ec2.internal    <none>           <none>
+
+  support       roman-efs-provisioner-6c9fdc5cfc-bvv55                       1/1     Running   0          32h   10.147.25.141   ip-10-147-25-56.ec2.internal    <none>           <none>'
+Kubernetes Pods: 'NAMESPACE     NAME                                                         READY   STATUS    RESTARTS   AGE   IP              NODE                            NOMINATED
+  NODE   READINESS GATES
+
+  datadog       datadog-cluster-agent-55477fc58b-66tqt                       1/1     Running   0          32h   10.147.25.95    ip-10-147-25-56.ec2.internal    <none>           <none>
+
+  datadog       datadog-kube-state-metrics-6fb56bf889-9ww67                  1/1     Running   0          32h   10.147.25.249   ip-10-147-25-56.ec2.internal    <none>           <none>
+
+  default       continuous-image-puller-mzng6                                1/1     Running   0          32h   10.147.25.97    ip-10-147-25-56.ec2.internal    <none>           <none>
+
+  default       hub-57ffd9747c-nb8fz                                         1/1     Running   0          32h   10.146.25.92    ip-10-146-25-64.ec2.internal    <none>           <none>
+
+  default       proxy-58bdccdb98-gc64g                                       1/1     Running   0          32h   10.147.25.217   ip-10-147-25-213.ec2.internal   <none>           <none>
+
+  default       user-placeholder-0                                           1/1     Running   0          32h   10.147.25.144   ip-10-147-25-56.ec2.internal    <none>           <none>
+
+  default       user-scheduler-c5fbd6b8d-fflns                               1/1     Running   0          32h   10.146.26.94    ip-10-146-26-17.ec2.internal    <none>           <none>
+
+  default       user-scheduler-c5fbd6b8d-zk2gg                               1/1     Running   0          32h   10.146.25.9     ip-10-146-25-64.ec2.internal    <none>           <none>
+
+  kube-system   aws-node-2jzpb                                               1/1     Running   0          32h   10.147.25.56    ip-10-147-25-56.ec2.internal    <none>           <none>
+
+  kube-system   aws-node-h47m8                                               1/1     Running   0          32h   10.146.26.17    ip-10-146-26-17.ec2.internal    <none>           <none>
+
+  kube-system   aws-node-jxk7j                                               1/1     Running   0          32h   10.146.25.64    ip-10-146-25-64.ec2.internal    <none>           <none>
+
+  kube-system   aws-node-twbnx                                               1/1     Running   0          32h   10.147.25.213   ip-10-147-25-213.ec2.internal   <none>           <none>
+
+  kube-system   cluster-autoscaler-aws-cluster-autoscaler-7d85444d49-wzxkm   1/1     Running   0          32h   10.147.25.169   ip-10-147-25-56.ec2.internal    <none>           <none>
+
+  kube-system   coredns-66cb55d4f4-9dwmp                                     1/1     Running   0          32h   10.147.25.45    ip-10-147-25-56.ec2.internal    <none>           <none>
+
+  kube-system   coredns-66cb55d4f4-nnthm                                     1/1     Running   0          32h   10.146.26.66    ip-10-146-26-17.ec2.internal    <none>           <none>
+
+  kube-system   kube-proxy-9fdx7                                             1/1     Running   0          32h   10.146.25.64    ip-10-146-25-64.ec2.internal    <none>           <none>
+
+  kube-system   kube-proxy-kkwl5                                             1/1     Running   0          32h   10.147.25.213   ip-10-147-25-213.ec2.internal   <none>           <none>
+
+  kube-system   kube-proxy-l2vzn                                             1/1     Running   0          32h   10.147.25.56    ip-10-147-25-56.ec2.internal    <none>           <none>
+
+  kube-system   kube-proxy-vd58l                                             1/1     Running   0          32h   10.146.26.17    ip-10-146-26-17.ec2.internal    <none>           <none>
+
+  support       roman-efs-provisioner-6c9fdc5cfc-bvv55                       1/1     Running   0          32h   10.147.25.141   ip-10-147-25-56.ec2.internal    <none>           <none>'
+Route-53 Host: 'test.roman.science.stsci.edu is an alias for a88c6fb16565a4f3cabb538289a94a31-360641126.us-east-1.elb.amazonaws.com.
+
+  a88c6fb16565a4f3cabb538289a94a31-360641126.us-east-1.elb.amazonaws.com has address
+  52.22.162.227
+
+  a88c6fb16565a4f3cabb538289a94a31-360641126.us-east-1.elb.amazonaws.com has address
+  34.235.194.72
+
+  a88c6fb16565a4f3cabb538289a94a31-360641126.us-east-1.elb.amazonaws.com has address
+  52.55.198.220'

--- a/tools/check_cluster.py
+++ b/tools/check_cluster.py
@@ -1,0 +1,584 @@
+#! /Usr/bin/env python
+
+"""Check properties of Terraformed resources and/or JupyterHub to verify good deployment.
+ignore the hub since it may not be delpoyed on the cluster yet.
+
+check creation date
+check for global hammer
+check for datadog
+"""
+
+import sys
+import os
+import subprocess
+import argparse
+import re
+import json
+
+import yaml
+
+TEST_SPEC = """
+Globals:
+  environment:
+    - DEPLOYMENT_NAME
+    - ENVIRONMENT
+    - JH_HOSTNAME
+    - ADMIN_ARN
+    - ACCOUNT_ID
+  constants:
+    V_K8S: "1.21"
+    MAX_NODE_AGE: 10d
+    MAX_EFS_FILE_SYSTEM_SIZE: 50000000000000
+Groups:
+  - group: Kubernetes Pods
+    command: kubectl get pods -A -o wide
+    parser: named_columns
+    assertions:
+    - name: All pods
+      all: READY=='1/1' and STATUS=='Running' and RESTARTS=='0'
+    - name: EFS provisioner
+      ok_rows==1: NAMESPACE=='support' and 'efs-provisioner' in NAME
+    - name: Kube Proxy
+      ok_rows>=4: NAMESPACE=='kube-system' and 'kube-proxy' in NAME
+    - name: Autoscaler
+      ok_rows==1: NAMESPACE=='kube-system' and 'cluster-autoscaler' in NAME
+    - name: AWS Pods
+      ok_rows>=4: NAMESPACE=='kube-system' and 'aws-node' in NAME
+    - name: Core DNS
+      ok_rows==2: NAMESPACE=='kube-system' and 'coredns' in NAME
+  - group: JupyterHub Pods
+    command: kubectl get pods -A -o wide
+    parser: named_columns
+    assertions:
+    - name: All pods
+      all: READY=='1/1' and STATUS=='Running' and RESTARTS=='0'
+    - name: Image puller
+      ok_rows==1: NAMESPACE=='default' and 'continuous-image-puller' in NAME
+    - name: Hub
+      ok_rows==1: NAMESPACE=='default' and 'hub' in NAME
+    - name: Proxy
+      ok_rows==1: NAMESPACE=='default' and 'proxy' in NAME
+    - name: User-scheduler
+      ok_rows==2: NAMESPACE=='default' and 'user-scheduler' in NAME
+    - name: User-placeholder
+      ok_rows==1: NAMESPACE=='default' and 'user-placeholder' in NAME
+  - group: JupyterHub Nodes
+    command: kubectl get nodes -A --show-labels=true
+    parser: named_columns
+    assertions:
+    - name: At least 4 STATUS Ready new Hub AMI ID
+      ok_rows>=4: STATUS=="Ready" # and HUB_AMI_ID in LABELS
+    - name: All Nodes Ready Status
+      all: STATUS=="Ready" or STATUS=="Ready,SchedulingDisabled"
+    - name: Kubernetes Version
+      all: V_K8S in VERSION
+    - name: Node Age
+      all: convert_age(AGE) < convert_age(MAX_NODE_AGE)
+    - name: Core us-east-1a
+      ok_rows==1:  "'roman-core' in LABELS and 't3.small' in LABELS and 'zone=us-east-1a' in LABELS"
+    - name: Core us-east-1b
+      ok_rows==1:  "'roman-core' in LABELS and 't3.small' in LABELS and 'zone=us-east-1b' in LABELS"
+    - name: Core us-east-1c
+      ok_rows==1:  "'roman-core' in LABELS and 't3.small' in LABELS and 'zone=us-east-1c' in LABELS"
+    - name: Notebook nodes
+      ok_rows>=1:  "'roman-notebook' in LABELS and 'r5.xlarge' in LABELS  and 'region=us-east-1' in LABELS"
+  - group: EKS Services
+    command:  kubectl get services -A
+    parser: named_columns
+    assertions:
+    - name: Datadog Cluster Agent Service
+      ok_rows==1: NAMESPACE=='datadog' and NAME=='datadog-cluster-agent' and TYPE=='ClusterIP' and _['EXTERNAL-IP']=='<none>' and _['PORT(S)']=='5005/TCP'
+    - name: Datadog Kube State Metrics Service
+      ok_rows==1: NAMESPACE=='datadog' and NAME=='datadog-kube-state-metrics' and TYPE=='ClusterIP' and _['EXTERNAL-IP']=='<none>' and _['PORT(S)']=='8080/TCP'
+    - name: Hub Service
+      ok_rows==1: NAMESPACE=='default' and NAME=='hub' and TYPE=='ClusterIP' and _['EXTERNAL-IP']=='<none>' and _['PORT(S)']=='8081/TCP'
+    - name: Kubernetes Service
+      ok_rows==1: NAMESPACE=='default' and NAME=='kubernetes' and TYPE=='ClusterIP' and _['EXTERNAL-IP']=='<none>' and _['PORT(S)']=='443/TCP'
+    - name: Proxy API Service
+      ok_rows==1: NAMESPACE=='default' and NAME=='proxy-api' and TYPE=='ClusterIP' and _['EXTERNAL-IP']=='<none>' and _['PORT(S)']=='8001/TCP'
+    - name: Proxy Public Service
+      ok_rows==1: NAMESPACE=='default' and NAME=='proxy-public' and TYPE=='LoadBalancer' and '.elb.amazonaws.com' in _['EXTERNAL-IP'] and '443:' in _['PORT(S)'] and '80:' in _['PORT(S)'] and 'TCP' in _['PORT(S)'] and 'UDP' not in  _['PORT(S)']
+    - name: Cluster Autoscaler Service
+      ok_rows==1: NAMESPACE=='kube-system' and NAME=='cluster-autoscaler-aws-cluster-autoscaler' and TYPE=='ClusterIP' and _['EXTERNAL-IP']=='<none>' and _['PORT(S)']=='8085/TCP'
+    - name: Kube DNS Service
+      ok_rows==1: NAMESPACE=='kube-system' and NAME=='kube-dns' and TYPE=='ClusterIP' and _['EXTERNAL-IP']=='<none>' and _['PORT(S)']=='53/UDP,53/TCP'
+  - group: EKS Deployments
+    command:  kubectl get deployments -A
+    parser: named_columns
+    assertions:
+    - name: Hub Deployment
+      ok_rows==1: NAMESPACE=='default' and NAME=='hub' and READY=='1/1' and _['UP-TO-DATE']=='1' and AVAILABLE=='1'
+    - name: Proxy Deployment
+      ok_rows==1: NAMESPACE=='default' and NAME=='proxy' and READY=='1/1' and _['UP-TO-DATE']=='1' and AVAILABLE=='1'
+    - name: User Scheduler Deployment
+      ok_rows==1: NAMESPACE=='default' and NAME=='user-scheduler' and READY=='2/2' and _['UP-TO-DATE']=='2' and AVAILABLE=='2'
+    - name: Cluster Autoscaler Deployment
+      ok_rows==1: NAMESPACE=='kube-system' and 'cluster-autoscaler' in NAME and READY=='1/1' and _['UP-TO-DATE']=='1' and AVAILABLE=='1'
+    - name: Core DNS Deployment
+      ok_rows==1: NAMESPACE=='kube-system' and 'coredns' in NAME and READY=='2/2' and _['UP-TO-DATE']=='2' and AVAILABLE=='2'
+    - name: EFS Provisioner Deployment
+      ok_rows==1: NAMESPACE=='support' and 'efs-provisioner' in NAME and READY=='1/1' and _['UP-TO-DATE']=='1' and AVAILABLE=='1'
+    - name: Datadog Cluster Agent Deployment
+      ok_rows==1: NAMESPACE=='datadog' and 'datadog-cluster-agent' in NAME and READY=='1/1' and _['UP-TO-DATE']=='1' and AVAILABLE=='1'
+    - name: Datadog Kube Metrics Deployment
+      ok_rows==1: NAMESPACE=='datadog' and 'datadog-kube-state-metrics' in NAME and READY=='1/1' and _['UP-TO-DATE']=='1' and AVAILABLE=='1'
+  - group: Route-53 Host
+    command: "host {JH_HOSTNAME}"
+    parser: raw
+    assertions:
+    - name: DNS Mapping
+      simple: "'{JH_HOSTNAME} is an alias for' in _"
+  - group: JupyterHub Index Page
+    command: "wget --no-check-certificate -O- {JH_HOSTNAME}"
+    parser: raw
+    assertions:
+    - name: Server Index Page
+      simple: "'HTTP request sent, awaiting response... 200 OK' in _"
+  - group: EFS File Systems
+    command: awsudo {ADMIN_ARN} aws efs describe-file-systems --output yaml --query FileSystems
+    parser: yaml
+    assertions:
+    - name: EFS Home Dirs
+      ok_rows==1: Name==DEPLOYMENT_NAME+'-home-dirs' and LifeCycleState=='available' and Encrypted==True and NumberOfMountTargets==3 and OwnerId==ACCOUNT_ID and aws_kv_dict(Tags)['stsci-backup']=='dmd-2w-sat'
+    - name: EFS Max Size
+      all: int(SizeInBytes['Value']) < MAX_EFS_FILE_SYSTEM_SIZE
+"""  # noqa: E501
+
+
+def convert_age(age_str):
+    """Convert k8s abbreviated-style datetime str e.g. 14d2h to an integer."""
+    age_str_org = age_str
+
+    def age_subst(age_str, letter, factor):
+        parts = age_str.split(letter)
+        if len(parts) == 2:
+            age_str = parts[0] + "*" + factor + "+" + parts[1]
+        return age_str
+
+    age_str = age_subst(age_str, "d", "60*60*24")
+    age_str = age_subst(age_str, "h", "60*60")
+    age_str = age_subst(age_str, "m", "60")
+    age_str = age_subst(age_str, "s", "1")
+    age_str = age_str[:-1]
+    print(f"convert_age({repr(age_str_org)}) --> {repr(age_str)} --> {eval(age_str)}")
+    return eval(age_str)
+
+
+def aws_kv_dict(key_value_dict_list):
+    """Convert AWS dict representation [{ 'Key':k, 'Value':v}, ...] to a Python dict."""
+    return {item["Key"]: item["Value"] for item in key_value_dict_list}
+
+
+def run(cmd, cwd=".", timeout=10):
+    """Run subprocess `cmd` in dir `cwd` failing if not completed within `timeout` seconds
+    of if `cmd` returns a non-zero exit status.
+
+    Returns both stdout+stderr from `cmd`.  (untested, verify manually if in doubt)
+    """
+    result = subprocess.run(
+        cmd.split(),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        check=True,
+        cwd=cwd,
+        timeout=timeout,
+    )  # maybe succeeds
+    return result.stdout
+
+
+def parse_named_columns(output):
+    """Return rows from a table string `output` as a sequence of dicts.
+    The first row should contain whitespace delimited column names.
+    Each subsequent row should contain whitespace delimited column values.
+
+    Given tabular `output` as found in many k8s commands:
+
+    col1_name         col2_name      ...
+    col1_row1_val     col2_row1_val  ...
+    col1_row2_val     col1_row2_val  ...
+    ...
+
+    Returns [ {col1_name: col1_row1_val, col2_name: col2_row1_val, ...},
+              {col1_name: col1_row2_val, col2_name: col2_row2_val, ...},
+              ... ]
+
+    Each dict in the returned sequence is suitable as a namespace for eval()
+    """
+    lines = output.splitlines()
+    columns = lines[0].split()
+    rows = []
+    for line in lines[1:]:
+        d = dict(zip(columns, line.split()))
+        d["_"] = d
+        rows.append(d)
+    return rows
+
+
+def parse_raw(output):
+    """Just return `output` as a single string assigned to dict key '_'
+    for reference in assertion expressions.
+
+    Returns {'_': output}
+    """
+    return dict(_=output)
+
+
+def parse_yaml(output):
+    """Return the YAML parsing of `output` string.  aws commands can
+    be filtered using the --query parameter to produce more manageable
+    output before YAML parsing.
+    """
+    return yaml.safe_load(output)
+
+
+def parse_json(output):
+    """Return the JSON parsing of `output` string.  aws commands can
+    be filtered using the --query parameter to produce more manageable
+    output before JSON parsing.
+    """
+    return json.loads(output)
+
+
+class Checker:
+    """The Checker class runs a number of tests defined in a `test_spec` string.
+
+    Commands
+    --------
+
+    Each Group includes a subprocess CLI command from which the output is captured,
+    parsed, and checked against various assertions.
+
+    Output Parsing
+    --------------
+
+    The command output is parsed using a parser which can be be one of
+    named_rows, raw, yaml, or json.
+
+    named_rows is ideal for parsing kubectl output in which each row
+    defines a set of variables as a dict.  named_rows requires that
+    column names and values do not contain spaces; generally it is not
+    a problem but not all kubectl output modes work.
+
+    raw simply returns { "_": cmd_output } so _ is used as a variable
+    in assertions to refer to the entire output string.
+
+    yaml and json return parsed command output using their respective
+    loaders.  The --query parameter of the 'aws' commands can be
+    useful for pre-filtering command output so that a simple direct
+    parsing is usable in assertions.
+
+    Test Assertions
+    ---------------
+
+    A series of assertions are evaluated on the parsed output from each group's command.
+
+    Assertions take the form:
+
+    simple: <python expression using parsed outputs to define variables, eval must pass.>
+
+    ok_rows_expr: <python expression using parsed outputs to define row variables, ok_rows_expr must be True.>
+
+    all: <python expression using parsed outputs to define row variables,  each row must pass.>
+
+    Examples of ok_rows expressions might be:
+
+    ok_rows==1
+    ok_rows>=3
+
+    Pseudo code for 'all' is:
+
+    ok_rows==len(total output rows)
+
+    ok_rows is assigned the number of times the assertion evaluates to True when run
+    against each of the row namespace dicts.  Hence overall test success does not
+    require every row to pass the assertion.
+
+    The `test_spec` specifies a string of YAML which defines:
+
+    Globals:
+      environment:
+        - env var1 needed in assertion expressions imported from os.environ
+        ...
+      constants:
+        - VAR: VAL a VAR needed in assertion expressions with the spec'd VAL
+        ...
+    Groups:
+    - group: <Command Group Name>
+      command: <UNIX subprocess command string>
+      parser: <named_rows|raw|yaml|json>
+      assertions:
+      - name: <Name defining check>
+        <simple|all|ok_rows_expr>:  <python expression>
+      - name: <Name defining check>
+        <simple|all|ok_rows_expr>:  <python expression>
+      ...
+    ...
+
+    NOTE: In the spec,  substitions for output vars, env vars, constants,
+      variables, and built-in functions occur in two basic ways:
+          - Using Python's f-string {} formatting.       (commands)
+          - Treated as a variable name to be eval'ed.    (assertions)
+      This is because commands are "".format()'ed but assertions are eval'ed,
+      each against similar namespaces with the caveat that the command formatting
+      includes no variables derived from it's own output.
+
+    if `output_file` is specified,  commands are run and outputs are
+       stored at the spec'ed path,  the checker exits w/o running tests.
+
+    if `input_file` is specified, it is presumed to be the path to command
+       output YAML stored by `output_file` and replaces running commands,
+       checks are run using the stored outputs.
+
+    input_file and output_file are mutually exclusive.
+
+    if `verbose` is specified then additional assertion-by-assertion,
+      row-by-row output is generated.
+
+    if `groups_regex` is specified,  only the group names which can be
+      searched by the regex are checked.  (case insensitive substrings
+      of group names work).
+
+    if `variables` is specified,  it should be a comma seperated string
+      of VAR=VAL pairs,  i.e.  VAR1=VAL1,VAR2=VAL2,...
+      These variables are added to the namespace used for running/eval'ing
+      commands and assertions and override values already defined in Globals.
+    """  # noqa: E501
+
+    def __init__(
+        self,
+        test_spec,
+        output_file,
+        input_file,
+        verbose,
+        groups_regex,
+        variables,
+    ):
+        self._output_file = output_file
+        self._input_file = input_file
+        self._verbose = verbose
+        self._groups_regex = groups_regex
+        print("===> Loading test spec")
+        self.loaded_spec = yaml.safe_load(test_spec)
+        self.variables = (
+            dict([var.split("=") for var in variables.split(",")]) if variables else []
+        )
+        self._outputs = {}
+        self._errors = 0
+
+    @property
+    def groups(self):
+        return self.loaded_spec["Groups"]
+
+    @property
+    def spec_environment(self):
+        return {
+            var: os.environ[var]
+            for var in self.loaded_spec.get("Globals", {}).get("environment", [])
+        }
+
+    @property
+    def spec_constants(self):
+        return self.loaded_spec.get("Globals", {}).get("constants", {})
+
+    @property
+    def builtin_functions(self):
+        return dict(
+            convert_age=convert_age,
+            aws_kv_dict=aws_kv_dict,
+        )
+
+    @property
+    def combined_environment(self):
+        env = dict()
+        env.update(self.spec_constants)
+        env.update(self.spec_environment)
+        env.update(self.variables)
+        env.update(self.builtin_functions)
+        return env
+
+    def main(self):
+        self.setup_outputs()
+        for check in self.groups:
+            if re.search(self._groups_regex, check["group"], re.IGNORECASE):
+                self.run_check(check)
+        if self._output_file:
+            self.store_outputs()
+        return self._errors
+
+    def setup_outputs(self):
+        """Fetch saved commands ouputs from file rather than running commands."""
+        if self._input_file:
+            with open(self._input_file) as file:
+                self._outputs = yaml.safe_load(file)
+        else:
+            self._outputs = {}
+
+    def store_outputs(self):
+        """Store command outputs to file for running offline later."""
+        print("=" * 80)
+        print("Saving", repr(self._output_file))
+        with open(self._output_file, "w+") as file:
+            yaml.dump(self._outputs, file)
+
+    def get_command_output(self, check):
+        group = check["group"]
+        if not self._input_file:
+            command = check.get("command").format(**self.combined_environment)
+            print("===> Fetching", repr(group), "with", repr(command))
+            print("=" * 80)
+            try:
+                self._outputs[group] = run(command).strip()
+            except Exception as exc:
+                error = f"Command FAILED for '{group}': '{command}' : '{str(exc)}'"
+                self.error(error)
+                self._outputs[group] = error
+        return self._outputs[group]
+
+    def run_check(self, check):
+        print("=" * 80)
+        output = self.get_command_output(check)
+        print(output)
+        print("=" * 80)
+        if self._output_file:
+            return
+        if not output.startswith("Command FAILED"):
+            parser = globals()[f"parse_{check['parser']}"]
+            namespaces = parser(output)
+            assertions = check.get("assertions", [])
+            self.check_assertions(check["group"], assertions, namespaces)
+            if not assertions:
+                print("======> No assertions defined.")
+
+    def check_assertions(self, group, assertions, namespaces):
+        for assertion in assertions:
+            assertion = dict(assertion)
+            name = assertion.pop("name")
+            print("===> Checking", repr(group), ":", repr(name), ":", assertion)
+            requirement, condition = list(assertion.items())[0]
+            condition = condition.format(**self.combined_environment)
+            if requirement == "simple":
+                self.verify_simple(name, namespaces, condition)
+            elif requirement.startswith(("ok_rows", "all")):
+                self.verify_rows(name, namespaces, requirement, condition)
+            else:
+                raise ValueError(
+                    f"Unhandled requirement: {requirement} for assertion: {assertion}"
+                )
+            print()
+
+    def verify_rows(self, name, namespaces, requirement, condition):
+        self.verbose(f"Checking '{name}': {repr(condition)}")
+        rows = []
+        for i, namespace in enumerate(namespaces):
+            self.verbose(f"Checking '{name}' #{i} : {condition} ... ", end="")
+            if self.eval_condition(name, namespace, condition):
+                rows.append(namespace)
+                self.verbose("OK")
+            else:
+                self.verbose("FAILED")
+                self.verbose("Namespace:", namespace)
+        if requirement == "all":
+            requirement = f"ok_rows=={len(namespaces)}"
+        if eval(requirement, {}, dict(ok_rows=len(rows))):
+            print(f"===> OK overall '{name}'")
+        else:
+            self.error(f"overall '{name}'")
+            self.verbose("Namespace:", namespace)
+
+    def verify_simple(self, name, namespace, condition):
+        if self.eval_condition(name, namespace, condition):
+            print(f"===> OK '{name}'")
+        else:
+            self.error(f"'{name}'")
+            self.verbose("Namespace:", namespace)
+
+    def eval_condition(self, name, namespace, condition):
+        namespace = dict(namespace)  # local no-side-effects copy
+        namespace.update(self.combined_environment)
+        return eval(condition, {}, namespace)
+
+    def verbose(self, *args, **keys):
+        if self._verbose:
+            print(*args, **keys)
+
+    def error(self, *args):
+        self._errors += 1
+        print("===> ERROR: ", *args)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Perform various cluster and hub checks to automatically detect basic anomalies."
+    )
+    parser.add_argument(
+        "--test-spec",
+        dest="test_spec",
+        action="store",
+        default=None,
+        help="Custom test specification.  Defaults to None meaning use built-in spec.",
+    )
+    parser.add_argument(
+        "--output-file",
+        dest="output_file",
+        action="store",
+        default=None,
+        help="Filepath to store outputs of test commands.",
+    )
+    parser.add_argument(
+        "--input-file",
+        dest="input_file",
+        action="store",
+        default=None,
+        help="Filepath to load previously stored test command results.",
+    )
+    parser.add_argument(
+        "--verbose",
+        dest="verbose",
+        action="store_true",
+        help="Include additional output.",
+    )
+    parser.add_argument(
+        "--groups-regex",
+        dest="groups_regex",
+        action="store",
+        default=".+",
+        help="Select groups to execute based on the specified regex,  defaulting to all groups."
+        "  Unique group substrings are valid, |-or patterns together. Case is irrelevant.",
+    )
+    parser.add_argument(
+        "--variables",
+        dest="variables",
+        action="store",
+        default=None,
+        help="Custom override variables which can be used in commands, assertions, etc."
+        "  --variables var1=val1,var2=val2,...",
+    )
+    return parser.parse_args()
+
+
+def main():
+    """Parse command line arguments and run the test spec.
+
+    Return the number of failing tests or 0 if all tests pass.
+    """
+    args = parse_args()
+    test_spec = open(args.test_spec).read().strip() if args.test_spec else TEST_SPEC
+    checker = Checker(
+        test_spec=test_spec,
+        output_file=args.output_file,
+        input_file=args.input_file,
+        verbose=args.verbose,
+        groups_regex=args.groups_regex,
+        variables=args.variables,
+    )
+    errors = checker.main()
+    if errors:
+        print("Total Errors:", errors)
+    else:
+        print("No Errors Detected")
+    return errors
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/check_cluster.py
+++ b/tools/check_cluster.py
@@ -160,8 +160,8 @@ def convert_age(age_str):
     age_str = age_subst(age_str, "m", "60")
     age_str = age_subst(age_str, "s", "1")
     age_str = age_str[:-1]
-    print(f"convert_age({repr(age_str_org)}) --> {repr(age_str)} --> {eval(age_str)}")
-    return eval(age_str)
+    print(f"convert_age({repr(age_str_org)}) --> {repr(age_str)} --> {eval(age_str)}")   # nosec
+    return eval(age_str)   # nosec
 
 
 def aws_kv_dict(key_value_dict_list):
@@ -480,7 +480,7 @@ class Checker:
                 self.verbose("Namespace:", namespace)
         if requirement == "all":
             requirement = f"ok_rows=={len(namespaces)}"
-        if eval(requirement, {}, dict(ok_rows=len(rows))):
+        if eval(requirement, {}, dict(ok_rows=len(rows))):   # nosec
             print(f"===> OK overall '{name}'")
         else:
             self.error(f"overall '{name}'")
@@ -496,7 +496,7 @@ class Checker:
     def eval_condition(self, name, namespace, condition):
         namespace = dict(namespace)  # local no-side-effects copy
         namespace.update(self.combined_environment)
-        return eval(condition, {}, namespace)
+        return eval(condition, {}, namespace)   # nosec
 
     def verbose(self, *args, **keys):
         if self._verbose:

--- a/tools/check_cluster.py
+++ b/tools/check_cluster.py
@@ -60,8 +60,8 @@ Groups:
       ok_rows==1: NAMESPACE=='default' and 'proxy' in NAME
     - name: User-scheduler
       ok_rows==2: NAMESPACE=='default' and 'user-scheduler' in NAME
-    - name: User-placeholder
-      ok_rows==1: NAMESPACE=='default' and 'user-placeholder' in NAME
+    # - name: User-placeholder
+    #   ok_rows==1: NAMESPACE=='default' and 'user-placeholder' in NAME
   - group: JupyterHub Nodes
     command: kubectl get nodes -A --show-labels=true
     parser: named_columns

--- a/tools/check_cluster.tests
+++ b/tools/check_cluster.tests
@@ -1,0 +1,124 @@
+Globals:
+  environment:
+    - DEPLOYMENT_NAME
+    - ENVIRONMENT
+    - JH_HOSTNAME
+    - ADMIN_ARN
+    - ACCOUNT_ID
+  constants:
+    V_K8S: "1.21"
+    MAX_NODE_AGE: 10d
+    MAX_EFS_FILE_SYSTEM_SIZE: 50000000000000
+Groups:
+  - group: Kubernetes Pods
+    command: kubectl get pods -A -o wide
+    parser: named_columns
+    assertions:
+    - name: All pods
+      all: READY=='1/1' and STATUS=='Running' and RESTARTS=='0'
+    - name: EFS provisioner
+      ok_rows==1: NAMESPACE=='support' and 'efs-provisioner' in NAME
+    - name: Kube Proxy
+      ok_rows>=4: NAMESPACE=='kube-system' and 'kube-proxy' in NAME
+    - name: Autoscaler
+      ok_rows==1: NAMESPACE=='kube-system' and 'cluster-autoscaler' in NAME
+    - name: AWS Pods
+      ok_rows>=4: NAMESPACE=='kube-system' and 'aws-node' in NAME
+    - name: Core DNS
+      ok_rows==2: NAMESPACE=='kube-system' and 'coredns' in NAME
+  - group: JupyterHub Pods
+    command: kubectl get pods -A -o wide
+    parser: named_columns
+    assertions:
+    - name: All pods
+      all: READY=='1/1' and STATUS=='Running' and RESTARTS=='0'
+    - name: Image puller
+      ok_rows==1: NAMESPACE=='default' and 'continuous-image-puller' in NAME
+    - name: Hub
+      ok_rows==1: NAMESPACE=='default' and 'hub' in NAME
+    - name: Proxy
+      ok_rows==1: NAMESPACE=='default' and 'proxy' in NAME
+    - name: User-scheduler
+      ok_rows==2: NAMESPACE=='default' and 'user-scheduler' in NAME
+    - name: User-placeholder
+      ok_rows==1: NAMESPACE=='default' and 'user-placeholder' in NAME
+  - group: JupyterHub Nodes
+    command: kubectl get nodes -A --show-labels=true
+    parser: named_columns
+    assertions:
+    - name: At least 4 STATUS Ready new Hub AMI ID
+      ok_rows>=4: STATUS=="Ready" # and HUB_AMI_ID in LABELS
+    - name: All Nodes Ready Status
+      all: STATUS=="Ready" or STATUS=="Ready,SchedulingDisabled"
+    - name: Kubernetes Version
+      all: V_K8S in VERSION
+    - name: Node Age
+      all: convert_age(AGE) < convert_age(MAX_NODE_AGE)
+    - name: Core us-east-1a
+      ok_rows==1:  "'roman-core' in LABELS and 't3.small' in LABELS and 'zone=us-east-1a' in LABELS"
+    - name: Core us-east-1b
+      ok_rows==1:  "'roman-core' in LABELS and 't3.small' in LABELS and 'zone=us-east-1b' in LABELS"
+    - name: Core us-east-1c
+      ok_rows==1:  "'roman-core' in LABELS and 't3.small' in LABELS and 'zone=us-east-1c' in LABELS"
+    - name: Notebook nodes
+      ok_rows>=1:  "'roman-notebook' in LABELS and 'r5.xlarge' in LABELS  and 'region=us-east-1' in LABELS"
+  - group: EKS Services
+    command:  kubectl get services -A
+    parser: named_columns
+    assertions:
+    - name: Datadog Cluster Agent Service
+      ok_rows==1: NAMESPACE=='datadog' and NAME=='datadog-cluster-agent' and TYPE=='ClusterIP' and _['EXTERNAL-IP']=='<none>' and _['PORT(S)']=='5005/TCP'
+    - name: Datadog Kube State Metrics Service
+      ok_rows==1: NAMESPACE=='datadog' and NAME=='datadog-kube-state-metrics' and TYPE=='ClusterIP' and _['EXTERNAL-IP']=='<none>' and _['PORT(S)']=='8080/TCP'
+    - name: Hub Service
+      ok_rows==1: NAMESPACE=='default' and NAME=='hub' and TYPE=='ClusterIP' and _['EXTERNAL-IP']=='<none>' and _['PORT(S)']=='8081/TCP'
+    - name: Kubernetes Service
+      ok_rows==1: NAMESPACE=='default' and NAME=='kubernetes' and TYPE=='ClusterIP' and _['EXTERNAL-IP']=='<none>' and _['PORT(S)']=='443/TCP'
+    - name: Proxy API Service
+      ok_rows==1: NAMESPACE=='default' and NAME=='proxy-api' and TYPE=='ClusterIP' and _['EXTERNAL-IP']=='<none>' and _['PORT(S)']=='8001/TCP'
+    - name: Proxy Public Service
+      ok_rows==1: NAMESPACE=='default' and NAME=='proxy-public' and TYPE=='LoadBalancer' and '.elb.amazonaws.com' in _['EXTERNAL-IP'] and '443:' in _['PORT(S)'] and '80:' in _['PORT(S)'] and 'TCP' in _['PORT(S)'] and 'UDP' not in  _['PORT(S)']
+    - name: Cluster Autoscaler Service
+      ok_rows==1: NAMESPACE=='kube-system' and NAME=='cluster-autoscaler-aws-cluster-autoscaler' and TYPE=='ClusterIP' and _['EXTERNAL-IP']=='<none>' and _['PORT(S)']=='8085/TCP'
+    - name: Kube DNS Service
+      ok_rows==1: NAMESPACE=='kube-system' and NAME=='kube-dns' and TYPE=='ClusterIP' and _['EXTERNAL-IP']=='<none>' and _['PORT(S)']=='53/UDP,53/TCP'
+  - group: EKS Deployments
+    command:  kubectl get deployments -A
+    parser: named_columns
+    assertions:
+    - name: Hub Deployment
+      ok_rows==1: NAMESPACE=='default' and NAME=='hub' and READY=='1/1' and _['UP-TO-DATE']=='1' and AVAILABLE=='1'
+    - name: Proxy Deployment
+      ok_rows==1: NAMESPACE=='default' and NAME=='proxy' and READY=='1/1' and _['UP-TO-DATE']=='1' and AVAILABLE=='1'
+    - name: User Scheduler Deployment
+      ok_rows==1: NAMESPACE=='default' and NAME=='user-scheduler' and READY=='2/2' and _['UP-TO-DATE']=='2' and AVAILABLE=='2'
+    - name: Cluster Autoscaler Deployment
+      ok_rows==1: NAMESPACE=='kube-system' and 'cluster-autoscaler' in NAME and READY=='1/1' and _['UP-TO-DATE']=='1' and AVAILABLE=='1'
+    - name: Core DNS Deployment
+      ok_rows==1: NAMESPACE=='kube-system' and 'coredns' in NAME and READY=='2/2' and _['UP-TO-DATE']=='2' and AVAILABLE=='2'
+    - name: EFS Provisioner Deployment
+      ok_rows==1: NAMESPACE=='support' and 'efs-provisioner' in NAME and READY=='1/1' and _['UP-TO-DATE']=='1' and AVAILABLE=='1'
+    - name: Datadog Cluster Agent Deployment
+      ok_rows==1: NAMESPACE=='datadog' and 'datadog-cluster-agent' in NAME and READY=='1/1' and _['UP-TO-DATE']=='1' and AVAILABLE=='1'
+    - name: Datadog Kube Metrics Deployment
+      ok_rows==1: NAMESPACE=='datadog' and 'datadog-kube-state-metrics' in NAME and READY=='1/1' and _['UP-TO-DATE']=='1' and AVAILABLE=='1'
+  - group: Route-53 Host
+    command: "host {JH_HOSTNAME}"
+    parser: raw
+    assertions:
+    - name: DNS Mapping
+      simple: "'{JH_HOSTNAME} is an alias for' in _"
+  - group: JupyterHub Index Page
+    command: "wget --no-check-certificate -O- {JH_HOSTNAME}"
+    parser: raw
+    assertions:
+    - name: Server Index Page
+      simple: "'HTTP request sent, awaiting response... 200 OK' in _"
+  - group: EFS File Systems
+    command: awsudo {ADMIN_ARN} aws efs describe-file-systems --output yaml --query FileSystems
+    parser: yaml
+    assertions:
+    - name: EFS Home Dirs
+      ok_rows==1: Name==DEPLOYMENT_NAME+'-home-dirs' and LifeCycleState=='available' and Encrypted==True and NumberOfMountTargets==3 and OwnerId==ACCOUNT_ID and aws_kv_dict(Tags)['stsci-backup']=='dmd-2w-sat'
+    - name: EFS Max Size
+      all: int(SizeInBytes['Value']) < MAX_EFS_FILE_SYSTEM_SIZE

--- a/tools/check_cluster.tests
+++ b/tools/check_cluster.tests
@@ -40,8 +40,8 @@ Groups:
       ok_rows==1: NAMESPACE=='default' and 'proxy' in NAME
     - name: User-scheduler
       ok_rows==2: NAMESPACE=='default' and 'user-scheduler' in NAME
-    - name: User-placeholder
-      ok_rows==1: NAMESPACE=='default' and 'user-placeholder' in NAME
+    # - name: User-placeholder
+    #   ok_rows==1: NAMESPACE=='default' and 'user-placeholder' in NAME
   - group: JupyterHub Nodes
     command: kubectl get nodes -A --show-labels=true
     parser: named_columns

--- a/tools/image-pull
+++ b/tools/image-pull
@@ -4,7 +4,8 @@ cd $IMAGE_DIR
 
 image-login
 
+IMAGE_ID=${1:-`echo ${IMAGE_ID} | sed -e's/unscanned-//g'`}
+
 echo "================================== Pulling ${IMAGE_ID} =============================="
-echo "WARNING:  this is pulling the *unscanned* tag"
 docker image rm $IMAGE_ID
 docker pull $IMAGE_ID


### PR DESCRIPTION
Added cluster_check.py to automate basic cluster and hub checks suitable for running automatically
  following push button or commit driven cluster and/or hub deployments,  or just as a quick look.
  Also includes one set of saved command results and a standalone test spec which is used to define
  and/or customize tests outside the script source code.
Added automatically defined JH_HOSTNAME to infrequent-env.
Modified image-pull to remove 'unscanned-' by default and/or permit specification of the IMAGE_ID to pull.
