### PR TITLE
Generalize get-datadog-key

### DIFF
--- a/tools/deploy-datadog
+++ b/tools/deploy-datadog
@@ -7,5 +7,5 @@ helm repo add datadog https://helm.datadoghq.com
 helm repo update
 
 helm upgrade --install datadog datadog/datadog -f datadog.yaml \
-    --set datadog.apiKey=$(get-datadog-api-key) \
+    --set datadog.apiKey=$(get-datadog-key api) \
     --create-namespace -n datadog

--- a/tools/get-datadog-api-key
+++ b/tools/get-datadog-api-key
@@ -1,6 +1,5 @@
 #!/usr/bin/bash
  
-secret=$(awsudo $ADMIN_ARN aws secretsmanager get-secret-value --secret-id ${DATADOG_API_KEY_ID} --region us-east-1 | grep 'SecretString' | awk -F: '{print $2}' | xargs | sed 's|["'\'']||g' | sed '
- s/,$//')
+secret=$(awsudo $ADMIN_ARN aws secretsmanager get-secret-value --secret-id ${DATADOG_API_KEY_ID} --region us-east-1 | grep 'SecretString' | awk -F: '{print $3}' | sed 's/\\"//g' | sed 's/}\",//')
 
 echo ${secret}

--- a/tools/get-datadog-key
+++ b/tools/get-datadog-key
@@ -1,0 +1,23 @@
+#!/usr/bin/bash
+
+
+export dd_key_type=$1
+if [ -z "$dd_key_type" ]; then
+    echo "Missing arg: key type (app or api)"
+    exit 1
+fi
+
+export dd_keys=$(awsudo $ADMIN_ARN aws secretsmanager get-secret-value --secret-id ${DATADOG_API_KEY_ID} --region us-east-1 --version-stage AWSCURRENT --query SecretString --output text)
+
+python<<EOF
+import os, json
+
+keys = os.environ.get('dd_keys')
+key_type = os.environ.get('dd_key_type')
+
+data = json.loads(keys)
+print(data[f'dd-dmd-awscloud-{key_type}key'])
+EOF
+
+
+

--- a/tools/get-datadog-key
+++ b/tools/get-datadog-key
@@ -1,6 +1,5 @@
 #!/usr/bin/bash
 
-
 export dd_key_type=$1
 if [ -z "$dd_key_type" ]; then
     echo "Missing arg: key type (app or api)"
@@ -18,6 +17,3 @@ key_type = os.environ.get('dd_key_type')
 data = json.loads(keys)
 print(data[f'dd-dmd-awscloud-{key_type}key'])
 EOF
-
-
-


### PR DESCRIPTION
Have the script accept either "api" or "app".

Update call to script in `deploy-datadog`.