### PR TITLE
Create new secrets decrypted "template" for Cognito RnD work

### DIFF
--- a/doc/example-secrets-env-decrypted-cognito-rnd.yaml
+++ b/doc/example-secrets-env-decrypted-cognito-rnd.yaml
@@ -1,0 +1,32 @@
+jupyterhub:
+    proxy:
+        secretToken: <REDACTED>
+        https:
+            enabled: true
+            type: offload
+        service:
+            annotations:
+                service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-east-1:<ACCOUNT ID>:certificate/<KEY ID>
+                service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
+                service.beta.kubernetes.io/aws-load-balancer-ssl-ports: https
+                service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "3600"
+    hub:
+        config:
+            GenericOAuthenticator:
+                login_service: AWS Cognito
+                client_id: <REDACTED>
+                client_secret: <REDACTED>
+                token_url: https://<REDACTED>.auth.us-east-1.amazoncognito.com/oauth2/token
+                authorize_url: https://<REDACTED>.auth.us-east-1.amazoncognito.com/oauth2/authorize
+                userdata_url: https://<REDACTED>.auth.us-east-1.amazoncognito.com/oauth2/userInfo
+                oauth_callback_url: https://<URL>/hub/oauth_callback
+                logout_redirect_url: https://<REDACTED>.auth.us-east-1.amazoncognito.com/oauth2/logout
+                userdata_method: GET
+                username_key: username
+                scope:
+                - openid
+                - profile
+                - email
+                userdata_params:
+                    state: state
+                    username: email


### PR DESCRIPTION
example-secrets-env-decrypted-cognito-rnd.yaml was added.

Note that this template also includes ACM related cert stuff, which will probably need to be replaced with our existing manual configuration as seen under the proxy section of https://github.com/spacetelescope/jupyterhub-deploy/blob/main/doc/example-secrets-env-decrypted.yaml.  I decided to leave this in here as it was the working example I used.