### PR TITLE
Safety waivers

### DIFF
--- a/deployments/jwebbinar/image/environments/safety.ignore
+++ b/deployments/jwebbinar/image/environments/safety.ignore
@@ -1,8 +1,7 @@
 # Format this file using vulnerability lines grepped out of "safety" output.
 # Blank lines or lines beginnning with # are ignored.
-
-# | tensorflow                 | 1.15.5    | <2.1.4                   | 40675    |
-# | tensorflow                 | 1.15.5    | <2.1.4                   | 40676    |
-# | tensorflow                 | 1.15.5    | <2.1.4                   | 40673    |
-# | tensorflow                 | 1.15.5    | <2.4.0                   | 40795    |
-# | tensorflow                 | 1.15.5    | <2.4.0                   | 40794    |
+| numpy                      | 1.22.1    | >0                       | 44715    |
+| numpy                      | 1.20.3    | <1.22.0                  | 44716    |
+| numpy                      | 1.20.3    | <1.22.0                  | 44717    |
+| numpy                      | 1.20.3    | <1.21.0                  | 43453    |
+| ipython                    | 7.28.0    | >=7.17.0,<7.31.1         | 44634    |

--- a/deployments/roman/image/environments/safety.ignore
+++ b/deployments/roman/image/environments/safety.ignore
@@ -1,8 +1,3 @@
 # Format this file using vulnerability lines grepped out of "safety" output.
 # Blank lines or lines beginnning with # are ignored.
-
-# | tensorflow                 | 1.15.5    | <2.1.4                   | 40675    |
-# | tensorflow                 | 1.15.5    | <2.1.4                   | 40676    |
-# | tensorflow                 | 1.15.5    | <2.1.4                   | 40673    |
-# | tensorflow                 | 1.15.5    | <2.4.0                   | 40795    |
-# | tensorflow                 | 1.15.5    | <2.4.0                   | 40794    |
+| numpy                      | 1.22.1    | >0                       | 44715    |

--- a/deployments/tike/image/environments/safety.ignore
+++ b/deployments/tike/image/environments/safety.ignore
@@ -1,3 +1,6 @@
 # Format this file using vulnerability lines grepped out of "safety" output.
 # Blank lines or lines beginnning with # are ignored.
 | tensorflow                 | 2.6.0     | ==2.6.0                  | 41161    |
+| numpy                      | 1.21.5    | <1.22.0                  | 44716    |
+| numpy                      | 1.21.5    | <1.22.0                  | 44717    |
+| numpy                      | 1.21.5    | >0                       | 44715    |


### PR DESCRIPTION
Added waivers for numpy-related security vulnerabilities detected by "safety" which either have no fix or are blocked by other pinning requirements.