### PR TITLE
git-sync blob-less clone

### DIFF
--- a/deployments/common/image/common-scripts/git-sync
+++ b/deployments/common/image/common-scripts/git-sync
@@ -115,7 +115,7 @@ class GitSync(object):
 
     def init_repo(self):
         logging.info(f'Repo {self.repo_dir} doesn\'t exist. Cloning...')
-        run(f'git clone --branch {self.branch_name} {self.git_url} {self.repo_dir}')
+        run(f'git clone --filter=blob:none  --branch {self.branch_name} {self.git_url} {self.repo_dir}')
         logging.info(f'Repo {self.repo_dir} initialized')
 
     def sync(self):


### PR DESCRIPTION
Added switch to git-sync clone to do a blobless clone.    This avoid downloading
every block in the repo history,  but does include the history and tree.   In theory
historical blobs are transparently downloaded if they are ever required.

This has two impacts due to speeding up post-startup-hook run times:  (1) faster logins (2) faster docker builds for the final steps which get repeated the most.

For tike cloning spacetelescope/notebooks,  2 minutes turns into 8 seconds.

We should hold this PR until (a) other updates are giving us clean builds/tests and (b) it won't introduce trouble for an imminent webbinar.