### PR TITLE
Disabled data download scripts for PDRs4All JWebbinar.

### DIFF
--- a/deployments/jwebbinar/image/Dockerfile
+++ b/deployments/jwebbinar/image/Dockerfile
@@ -43,15 +43,6 @@ RUN cd /tmp && \
     make && \
     make install
 
-# Download and unzip PDRs4All dataset from Box
-# This is for the PDRs4ALL Jwebbinar June 2022
-
-
-RUN echo -e "cd /tmp\ncurl -L -v "https://stsci.box.com/shared/static/jpz5eysq5073og2q5g0vgnzw9tdhmw8u.zip" -o PDRs4All.zip\nunzip -o PDRs4All.zip -d PDRs4All/\nrm PDRs4All.zip \nrsync --ignore-existing -ahv --no-perms -O --no-o  --no-g --exclude='*__MACOSX*' /tmp/PDRs4All /home/jovyan/\n/opt/common-scripts/set-notebook-kernel jwebbinar /home/jovyan/PDRs4All/*/*.ipynb || true"  > /opt/common-scripts/prepare-data.sh
-
-RUN chmod +x /opt/common-scripts/prepare-data.sh
-
-
 
 
 # ----------------------------------------------------------------------

--- a/deployments/jwebbinar/image/environments/setup-notebooks
+++ b/deployments/jwebbinar/image/environments/setup-notebooks
@@ -10,9 +10,6 @@
 #/opt/common-scripts/set-notebook-kernel jdaviz jwebbinar_prep/mos_session/Mosviz_solutions.ipynb
 #/opt/common-scripts/set-notebook-kernel jwebbinar /home/$NB_USER/PDRs4All/*/*.ipynb || true 
 
-#Rsync data from PDRs4All into home directory and change owner to jovyan user
-/opt/common-scripts/prepare-data.sh && chown jovyan -R /home/jovyan/PDRs4All/ 
-
 # --- mkdir -p /opt/environments/jwebbinar/tests
 # --- mkdir -p /opt/environments/jdaviz/tests
 # --- ls -1 /home/jovyan/jwebbinar_prep/pointsource_imaging/MIRI_Aperture_Photometry_*.ipynb | grep -v __ | grep -v _live  >/opt/environments/jwebbinar/tests/notebooks


### PR DESCRIPTION
Since JWebbinar 15 is completed, this update disables the inline script to pull the notebook data at hub startup. 