### PR TITLE
JUSI-965 JH Helm Config Overwrite Checker

### DIFF
--- a/tools/check-config
+++ b/tools/check-config
@@ -1,0 +1,21 @@
+#! /bin/bash -eu
+
+# Script to detect possible config/values overwrites which normally happen silently in Helm.
+#   Automatically runs using our 4 JH YAML config files.
+#
+# Note that these results may not be identical to what Helm does;  nevertheless, it can suggest
+#   possible problems.  To see offical Helm output run
+#      helm get values <release, e.g. roman-dev>
+#   Output from which is also included in the tail of the deploy-jupyterhub output.
+#
+# Warnings are written to stderr
+# The result of merging the specified files is written to stdout
+
+cd $JUPYTERHUB_DIR
+
+secrets-cat >secrets.yaml
+
+yaml-merge  deployments/common/config/all.yaml  deployments/${DEPLOYMENT_NAME}/config/common.yaml  deployments/${DEPLOYMENT_NAME}/config/dev.yaml   secrets.yaml
+
+rm secrets.yaml
+

--- a/tools/deploy-jupyterhub
+++ b/tools/deploy-jupyterhub
@@ -35,4 +35,8 @@ rm ${tmp_decrypted}
 # Only use 1 more IP address than is needed at all times
 kubectl set env ds aws-node -n kube-system WARM_IP_TARGET=1
 
+echo ======================= Combined Helm Config Files =======================
+helm get values ${DEPLOYMENT_NAME}-${ENVIRONMENT}
+echo ==========================================================================
+
 kubectl get svc proxy-public

--- a/tools/yaml-merge
+++ b/tools/yaml-merge
@@ -1,0 +1,57 @@
+#! /usr/bin/env python
+
+"""Quick and dirty script that performs a "Helm-like" merge and points out
+areas where a file in a series of files will overwrite content from a previous
+file rather than add to it.
+"""
+
+import sys
+import yaml
+import copy
+
+
+def log(*args):
+    print(*args, file=sys.stderr)
+
+
+def deep_merge(f, m1, m2, path=[]):
+    m1 = copy.deepcopy(m1)
+    for key in m2:
+        if key in m1:
+            if isinstance(m1[key], dict) and isinstance(m2[key], dict):
+                m1[key] = deep_merge(f, m1[key], m2[key], path + [key])  # combination
+            else:
+                if m1[key] != m2[key]:
+                    log("WARNING: merging file", f, "at", path)
+                    log()
+                    log("------- results in replacing:")
+                    log()
+                    log(yaml.dump(m1[key]))
+                    log("------- with:")
+                    log()
+                    log(yaml.dump(m2[key]))
+                    log("-------")
+                m1[key] = m2[key]  # replacement
+        else:
+            m1[key] = m2[key]  # insertion
+    return m1
+
+
+def merge_file(merger, file_n):
+    with open(file_n) as f:
+        new_merger = yaml.safe_load(f)
+    assert isinstance(merger, dict)
+    assert isinstance(new_merger, dict)
+    return deep_merge(file_n, merger, new_merger)
+
+
+def main():
+    files = sys.argv[1:]
+    merger = {}
+    for i in range(len(files)):
+        merger = merge_file(merger, files[i])
+    print(yaml.dump(merger))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Attempts to improve on the situation where our 4 Helm config files for JH (all, common, sdlc, secrets) are combined with 
  silent replacements occurring potentially losing intended config.

For managing JH YAML config overwrites,  added Helm command to dump
  combined values of last JH Helm release to deploy-jupyterhub.

Also added scripts check-config and yaml-merge to automatically choose
  the YAML configs associated with the current mission,  merge them,
  and issue warnings when downstream files replace content from earlier
  files in the merge.   Run "check-config"