### PR TITLE
OAuth and role/scoped perms for EFS quotas and announcement services

### DIFF
--- a/doc/example-secrets-env-decrypted.yaml
+++ b/doc/example-secrets-env-decrypted.yaml
@@ -16,20 +16,24 @@ jupyterhub:
                     REDACTED
                     -----END CERTIFICATE-----
     hub:
+        loadRoles:
+            efs-quota:
+                scopes:
+                    - read:users
+                    - servers
         services:
             efs-quota:
                 api_token: "<generate token: openssl random --hex 32>"
-                admin: true
             announcement:
                 url: http://hub:8881
                 api_token: "<generate token: openssl random --hex 32>"
-                admin: true
                 command:
                     - python3
                     - /usr/share/jupyterhub/announcements.py
                     - -p
                     - "8881"
-                oauth_redirect_uri: "https://<JH full DNS name>/services/announcement/oauth_callback"
+                oauth_redirect_uri: "/services/announcement/oauth_callback"
+                oauth_no_confirm: true
                 environment:
                     PUBLIC_HOST: "https://<JH full DNS name>"
         networkPolicy:


### PR DESCRIPTION
These are improvements to service security enabled by the update to JupyterHub-3.0
EFS quotas traded admin perms for scopes like those used by the idle culler.
Announcements relinquished admin perms altogether.
Authentication from notebook servers to the announcement service was converted to OAuth with confirmation (separate authorize page) turned off since it is a background service.
Calls to GET announcements using username "all" return a 404 since only "system" and real usernames work for GET.
Updated example secrets with new service configuration.