### PR TITLE
Adds persistence to EFS to the announcements service

### DIFF
--- a/deployments/common/config/all.yaml
+++ b/deployments/common/config/all.yaml
@@ -14,6 +14,14 @@ jupyterhub:
     extraFiles:
       announcements_service:
         mountPath: /usr/share/jupyterhub/announcements.py
+    extraVolumes:
+      - name: quota-control
+        persistentVolumeClaim:
+          claimName: quota-control-jh-pvc
+    extraVolumeMounts:
+      - name: quota-control
+        mountPath: "/announcements"
+        subPath: "announcements"
   proxy:
     chp:
       pdb:

--- a/deployments/common/services/announcements.py
+++ b/deployments/common/services/announcements.py
@@ -1,13 +1,17 @@
+import os
+import sys
+import asyncio
 import argparse
 import datetime
 import json
-import os
-import sys
-from collections import defaultdict
 import re
 import uuid
+import time
+import pickle
+from collections import defaultdict
+from functools import partial
 
-from tornado import escape, ioloop, web
+from tornado import escape, web
 
 from jupyterhub.services.auth import HubOAuthenticated, HubOAuthCallbackHandler
 
@@ -92,20 +96,130 @@ def wlog(*args):
 
 # ----------------------------------------------------------------------
 
-ANNOUNCEMENTS = defaultdict(list)
-
 SYSTEM_USERS = ["efs-quota", "announcement"]
 
 MESSAGE_Q_LEN = 5
 
 
+class Message:
+    def __init__(self, username, timestamp, expires, level, message):
+        self.username = username
+        self.timestamp = timestamp
+        self.expires = expires
+        self.level = level
+        self.message = message
+
+
+def dt_from_iso(iso):
+    return datetime.datetime.fromisoformat(iso.split(".")[0])
+
+
+def delta_from_spec(spec):
+    days = int(spec.split("-")[0], 10) if "-" in spec else 0
+    hms = spec.split("-")[1] if "-" in spec else spec
+    hours, minutes, seconds = map(int, hms.split(":"))
+    return datetime.timedelta(days=days, hours=hours, minutes=minutes, seconds=seconds)
+
+
+class Announcements:
+    def __init__(self, savefile):
+        self.savefile = savefile
+        self.store = None
+        self.dirty = False
+        self.load()
+
+    def load(self):
+        try:
+            wlog(f"Loading {self.savefile}...")
+            with open(self.savefile, "rb") as file:
+                self.store = pickle.load(file)  # nosec
+            wlog(f"Loaded {self.savefile}.")
+            self.dirty = False
+        except Exception:
+            wlog(f"Loading {self.savefile} failed.  Clearing all.")
+            self.store = defaultdict(list)
+            self.dirty = True
+
+    def save(self):
+        wlog(f"Saving {self.savefile}...")
+        with open(self.savefile, "wb+") as file:
+            pickle.dump(self.store, file)
+        wlog(f"Saved {self.savefile}.")
+        self.dirty = False
+
+    def clear(self, username, clear_regex=".*"):
+        usernames = self.store.keys() if username == "all" else [username]
+        for username in usernames:
+            for msg in list(self.store[username]):
+                if re.search(clear_regex, msg.message):
+                    self.store[username].remove(msg)
+                    self.dirty = True
+
+    def put(self, username, message):
+        self.store[username].append(message)
+        self.rotate(username)
+        self.dirty = True
+
+    def rotate(self, username, q_len=MESSAGE_Q_LEN):
+        if len(self.store[username]) > q_len:
+            self.store[username] = self.store[username][1:]  # drop oldest message
+            self.dirty = True
+
+    def remove_expired(self):
+        now = datetime.datetime.now()
+        for user, messages in self.store.items():
+            for msg in list(messages):
+                timestamp = dt_from_iso(msg.timestamp)
+                expires = delta_from_spec(msg.expires)
+                if timestamp + expires <= now:
+                    messages.remove(msg)
+                    self.dirty = True
+
+    def get(self, username):
+        g_popup, global_table_html = self.html("system", "System")
+        u_popup, user_table_html = self.html(username, f"User {username}")
+        if global_table_html and user_table_html:
+            global_table_html += "<br/>"
+        return g_popup or u_popup, global_table_html + user_table_html
+
+    def html(self, user, title):
+        messages = []
+        popup = False
+        for msg in self.store[user]:
+            if msg.level.lower() in ["warning", "error", "critical"]:
+                popup = True
+            messages.extend(self._format_message(msg.timestamp, msg.level, msg.message))
+        html = table([p(title, style=".stsci.header")] + messages) if messages else ""
+        wlog(f"announcement{title}: {popup} - {html}")
+        return popup, html
+
+    def _format_message(self, time, level, msg):
+        return tr(
+            td(time.split(".")[0], style=".stsci.time"),
+            td(f"{level.upper()}", style=f".stsci.{level.lower()}"),
+            td(msg, style=".stsci.message"),
+        )
+
+
+# ----------------------------------------------------------------------
+
+ANNOUNCEMENTS = Announcements("/announcements/messages.pkl")
+
+
 class AnnouncementRequestHandler(HubOAuthenticated, web.RequestHandler):
     """Dynamically manage page announcements"""
+
+    def prepare(self):
+        wlog(self.request)
 
     def _check_admin_user(self):
         username = self.get_current_user()["name"]
         if username not in SYSTEM_USERS:
             raise web.HTTPError(404)
+
+    @property
+    def username(self):
+        return self.request.uri.split("/")[-1]
 
     @web.authenticated  # but only accessible to the service user
     def post(self):
@@ -114,85 +228,42 @@ class AnnouncementRequestHandler(HubOAuthenticated, web.RequestHandler):
         doc = escape.json_decode(self.request.body)
         username = doc["username"]
         timestamp = doc.get("timestamp", now())
+        expires = doc.get("expires", "2-00:00:00")
         replace = doc.get("replace", None)
         if replace:
-            user_messages = list(ANNOUNCEMENTS[username])
-            for message in user_messages:
-                if re.search(replace, message[3]):
-                    ANNOUNCEMENTS[username].remove(message)
-        message = (username, timestamp, doc["level"], doc["announcement"])
-        ANNOUNCEMENTS[username].append(message)
-        if len(ANNOUNCEMENTS[username]) > MESSAGE_Q_LEN:
-            ANNOUNCEMENTS[username] = ANNOUNCEMENTS[username][1:]  # drop oldest message
-        self.write_to_json(message)
-
-    def prepare(self):
-        wlog(self.request)
+            ANNOUNCEMENTS.clear(username, replace)
+        msg = Message(username, timestamp, expires, doc["level"], doc["announcement"])
+        ANNOUNCEMENTS.put(username, msg)
+        self.write_to_json(msg.__dict__)
 
     @web.authenticated
     def get(self):
         """Retrieve announcement"""
-        g_popup, global_table_str = self._announcements("system", "System")
-
         # From notebook or cmd line client API token
         username = self.get_current_user()["name"]
-
         # cmd line client can specify which user to pull
         if username in SYSTEM_USERS:
-            username = self.request.uri.split("/")[-1]
+            username = self.username
         if username == "all":
             raise web.HTTPError(
                 status_code=400,
                 log_message="Bad request:  username==all is not supported for GET",
             )
-
-        u_popup, user_table_str = self._announcements(username, f"User {username}")
-
-        wlog("global_table_str:", global_table_str)
-        wlog("user_table_str:", user_table_str)
-
-        if global_table_str and user_table_str:
-            global_table_str += "<br/>"
-
+        popup, html = ANNOUNCEMENTS.get(username)
         storage = dict(
-            announcement=global_table_str + user_table_str,
+            announcement=html,
             timestamp=now(),
             user=username,
-            popup=g_popup or u_popup,
+            popup=popup,
         )
-
         self.write_to_json(storage)
-
-    def _announcements(self, user, title):
-        messages = []
-        popup = False
-        for message in ANNOUNCEMENTS[user]:
-            if message[2].lower() in ["warning", "error", "critical"]:
-                popup = True
-            messages.extend(self._format_message(*message))
-        if messages:
-            return popup, table([p(title, style=".stsci.header")] + messages)
-        else:
-            return popup, ""
-
-    def _format_message(self, username, time, level, msg):
-        return tr(
-            td(time.split(".")[0], style=".stsci.time"),
-            td(f"{level.upper()}", style=f".stsci.{level.lower()}"),
-            td(msg, style=".stsci.message"),
-        )
 
     @web.authenticated
     def delete(self):
         """Clear announcement"""
-        global ANNOUNCEMENTS
         self._check_admin_user()
-        username = self.request.uri.split("/")[-1]
-        if username == "all":
-            ANNOUNCEMENTS = defaultdict(list)
-        else:
-            ANNOUNCEMENTS[username] = []
-        self.write_to_json([username])
+        ANNOUNCEMENTS.clear(self.username)
+        self.write_to_json([self.username])
 
     def write_to_json(self, doc):
         """Write dictionary document as JSON"""
@@ -205,11 +276,35 @@ class AnnouncementRequestHandler(HubOAuthenticated, web.RequestHandler):
 # ----------------------------------------------------------------------
 
 
-def main():
-    args = parse_arguments()
-    application = create_application(**vars(args))
-    application.listen(args.port)
-    ioloop.IOLoop.current().start()
+def persist_thread():
+    """Periodically check to see if any messages should expire or the contents
+    of ANNOUNCEMENTS have otherwise changed.   This function is blocking on
+    sleep and a write to disk so it will stall whatever event loop it runs
+    in.
+    """
+    while True:
+        time.sleep(10)
+        ANNOUNCEMENTS.remove_expired()
+        if ANNOUNCEMENTS.dirty:
+            ANNOUNCEMENTS.save()
+
+
+async def call_blocking(func, *args, **keys):
+    """Run the specified synchronous function in a background thread
+    so that it doesn't stall the main thread during its blocks.
+    """
+    binding = partial(func, *args, **keys)
+    binding.__doc__ = f"partial: {func.__doc__}"
+    loop = asyncio.get_event_loop()
+    return loop.run_in_executor(None, binding)
+
+
+async def announce_persist():
+    """Create a simple async function which can be called by gather()."""
+    await call_blocking(persist_thread)
+
+
+# ----------------------------------------------------------------------
 
 
 def parse_arguments():
@@ -237,5 +332,20 @@ def create_application(api_prefix=r"/", handler=AnnouncementRequestHandler, **kw
     )
 
 
+async def announce_handler_main():
+    args = parse_arguments()
+    app = create_application(**vars(args))
+    app.listen(args.port)
+    shutdown = asyncio.Event()
+    await shutdown.wait()
+
+
+# ----------------------------------------------------------------------
+
+
+async def main():
+    await asyncio.gather(announce_handler_main(), announce_persist())
+
+
 if __name__ == "__main__":
-    main()
+    asyncio.run(main())

--- a/tools/announce
+++ b/tools/announce
@@ -5,6 +5,7 @@ import sys
 import argparse
 import subprocess
 import datetime
+import re
 
 import requests
 from requests.adapters import HTTPAdapter
@@ -123,7 +124,7 @@ class AnnouncementRestApi(RestApi):
 
     prefix = "/services/announcement/latest"
 
-    def send_message(self, level, message, username=None, replace=None):
+    def send_message(self, level, message, username=None, replace=None, expires='2-00:00:00'):
         """Post a message to the announment service and return."""
         return self.post(
             level=level,
@@ -131,6 +132,7 @@ class AnnouncementRestApi(RestApi):
             username=username,
             timestamp=now(),
             replace=replace,
+            expires=expires,
         )
 
     def clear_announcements(self, username="all"):
@@ -140,6 +142,13 @@ class AnnouncementRestApi(RestApi):
     def get_announcements(self, username="all"):
         return self.get(f"/{username}")
 
+
+def deltatime(s):
+    try:
+        assert re.match(r"\d+\-\d\d:\d\d:\d\d", s)
+        return s
+    except Exception:
+        raise ValueError("Bad deltatime format for '--expires' should be DAYS-HH:MM:SS.")
 
 # ======================================================================================
 
@@ -206,6 +215,15 @@ new messages.
         metavar="<username>",
         help="User to send message to,  or 'system' (default) for a message sent to all users.",
     )
+    parser.add_argument(
+        "--expires",
+        dest="expires",
+        action="store",
+        default=None,
+        metavar="<expires>",
+        type=deltatime,
+        help="Time delta DAYS-HH:MM:SS after which this message expires and is cleared, default='2-00:00:00'.",
+    )
     return parser.parse_args(), parser
 
 
@@ -220,7 +238,7 @@ def main():
     api = AnnouncementRestApi(hub_url, api_token=get_api_token(), api_cert=api_cert)
 
     if args.put:
-        api.send_message(args.level, args.put, args.username, args.replace)
+        api.send_message(args.level, args.put, args.username, args.replace, args.expires)
     elif args.clear:
         api.clear_announcements(args.username)
     elif args.get:


### PR DESCRIPTION
Adds persistence to EFS to the announcements service
  via a background thread which "syncs" every 10 seconds when announcements change.
Adds expiration periods to announcement messages and announce CLI. Mounts /efs/quota-control/announcements at 
   /announcements in the hub pod for message persistence.
Significant announcement service refactoring to improve code quaility as
  complexity rises.