### PR TITLE
Update for docker-stacks for new base image docker-stacks-foundation

### DIFF
--- a/tools/image-base
+++ b/tools/image-base
@@ -46,7 +46,9 @@ build_jh() {
     docker build --rm --force-rm -t ${OWNER}/${STACK}:latest ./${STACK} --build-arg OWNER=${OWNER} --progress plain $*
 }
 
-build_jh  base-notebook     --build-arg ROOT_CONTAINER=${OWNER}/ubuntu-certs:latest
+build_jh  docker-stacks-foundation  --build-arg ROOT_CONTAINER=${OWNER}/ubuntu-certs:latest
+
+build_jh  base-notebook     --build-arg ROOT_CONTAINER=${OWNER}/docker-stacks-foundation:latest
 
 build_jh  minimal-notebook  --build-arg BASE_CONTAINER=${OWNER}/base-notebook:latest
 

--- a/tools/image-build-all
+++ b/tools/image-build-all
@@ -18,10 +18,6 @@ for USE_FROZEN in $FREEZE_MODES; do
         # tags for tracking here only, not intended for push, not valid for e.g. running on hub
         export IMAGE_ID=${IMAGE_ID}-${USE_FROZEN}
         export COMMON_ID=${COMMON_ID}-${USE_FROZEN}
-        if [[ `docker buildx ls | grep ${id}` == "1" ]];  then
-            docker buildx create --use --name ${id}
-        fi
-        nohup image-build 2>&1 >${id}.log &
-        sleep 5
+        image-build 2>&1 >${id}.log
     done
 done


### PR DESCRIPTION
Adds a new image between our cert image and base-image:  docker-stacks-foundation.  Normally docker-stacks-foundation now directly follows Ubuntu instead of base-image.
Modified image-build-all to build serially so it works with colima.