### PR TITLE
Ditch .x file complexity

### DIFF
--- a/tools/image-base
+++ b/tools/image-base
@@ -10,7 +10,7 @@ echo "========================= Building Base Image ========================"
 OWNER=stsci-jh
 
 cd ${JUPYTERHUB_DIR}/deployments/common/image
-docker build --progress plain --tag ${OWNER}/ubuntu-certs --file Dockerfile.certs.x \
+docker build --progress plain --tag ${OWNER}/ubuntu-certs --file Dockerfile.certs \
        --build-arg USE_FROZEN=${USE_FROZEN} \
        --build-arg PIP_SWITCHES="${PIP_SWITCHES}" \
        --build-arg CLEAR_PKG_CACHES="${CLEAR_PKG_CACHES}" \

--- a/tools/image-build
+++ b/tools/image-build
@@ -28,13 +28,12 @@ image-base
 # Build STScI shared layer for all deployments
 cd ${COMMON_IMAGE_DIR}
 echo "========================= Building Common Image ========================"
-time docker build --progress plain --tag ${COMMON_ID} --tag notebook-common --build-arg BASE_IMAGE=stsci-jh/scipy-notebook .  --file Dockerfile.x
-
+time docker build --progress plain --tag ${COMMON_ID} --tag notebook-common --build-arg BASE_IMAGE=stsci-jh/scipy-notebook .  --file Dockerfile
 # ..................................................................................
 # Build custom layers for this deployment
 cd ${IMAGE_DIR}
 echo "========================= Building $IMAGE_ID USE_FROZEN=${USE_FROZEN} =========================="
-time docker build --progress plain --tag ${IMAGE_ID} --tag "notebook-${DEPLOYMENT_NAME}" --build-arg BASE_IMAGE=${COMMON_ID} . --file Dockerfile.x
+time docker build --progress plain --tag ${IMAGE_ID} --tag "notebook-${DEPLOYMENT_NAME}" --build-arg BASE_IMAGE=${COMMON_ID} . --file Dockerfile
 
 # ..................................................................................
 # Optionally update requirements used by frozen and chilly builds.
@@ -44,22 +43,18 @@ if [[ "$FREEZE_CHILL" == "1" ]]; then
     # information as possible, not yet perfect/complete, may require
     # examination of diffs and manual updates to reject bad changes.
     if [[ "$USE_FROZEN" == "0" ]] || [[ "$USE_FROZEN" == "2" ]]; then
-	echo "========================= Freezing Requirements =========================="
-	time image-freeze
+        echo "========================= Freezing Requirements =========================="
+        time image-freeze
     fi
-    
+
     # Only chill for floating builds,  the first time frozen requirements are created since
     # re-chilling should not really change the frozen baseline used to determine the latest
     # chill... althought it might by accident due to the chilly changes to frozen if we do
     # this every time.
     if [[ "$USE_FROZEN" == "0" ]]; then
-	echo "========================= Chilling Requirements ========================="
-	time image-chill
+        echo "========================= Chilling Requirements ========================="
+        time image-chill
     fi
 fi
 
-# Remove buildkit caching "enhanced" Dockerfile.x's.
-# cd ${JUPYTERHUB_DIR}
-# docker_dirs="deployments/common  deployments/${DEPLOYMENT_NAME}"
-# find ${docker_dirs} -name 'Dockerfile*.x' | xargs rm -f
 )

--- a/tools/image-update
+++ b/tools/image-update
@@ -56,45 +56,6 @@ fi
 
 
 # -------------------------------------------------------------------------
-# Substitute RUN commands in Dockerfiles with RUN ${BUILDKIT} to enable package
-#   caching to reduce network package downloads.
-#
-# In a perfect world we'd just write this in Dockerfiles:
-#
-# RUN  ${BUILDKIT}  <command>
-#
-# but unfortunately Docker treats ${BUILDKIT} literally rather than expanding
-# it as a modifier to the RUN statement.
-#
-# Consequently, in our framework Dockerfiles are first pre-processed into .x
-# versions which either include or omit the buildkit switches defined below in
-# the image-update script.  While not saved, the .x file is what is actually
-# passed to docker build.  In theory, these caching options are a performance
-# optimzation only.  If in doubt, set USE_BUILDKIT_CACHING=0.
-#
-if [[ "${USE_BUILDKIT_CACHING}" == "1" ]]; then
-    export BUILDKIT="--mount=type=cache,sharing=private,target=/home/jovyan/.cache,uid=1000,gid=100"
-    export BUILDKIT="${BUILDKIT} --mount=type=cache,sharing=private,target=/var/cache/apt,uid=1000,gid=100"
-else
-    export BUILDKIT=""
-fi
-
-# export BUILDKIT="${BUILDKIT} --mount=type=cache,sharing=private,target=/opt/conda/pkgs,uid=1000,gid=100"
-
-
-cd ${JUPYTERHUB_DIR}
-docker_dirs="deployments/common  deployments/${DEPLOYMENT_NAME}"
-find ${docker_dirs} -name 'Dockerfile*.x' | xargs rm -f
-
-for dockerfile in `find ${docker_dirs} -name 'Dockerfile*'`; do
-    if [[ "${USE_BUILDKIT_CACHING}" == "1" ]]; then
-        sed -e"s%RUN %RUN ${BUILDKIT} %g" <$dockerfile >$dockerfile.x
-    else
-        cp $dockerfile $dockerfile.x
-    fi
-done
-
-# -------------------------------------------------------------------------
 # Ideally mission images are defined by a Dockerfile created from two parts
 # which are concatenated:
 #
@@ -111,9 +72,7 @@ cd $IMAGE_DIR
 
 if [[ -f Dockerfile.custom ]]; then
    # Combine Dockerfile.custom with the common "trailer" to create Dockerfile
-   # .x versions include buildkit substitutions
    cat Dockerfile.custom ../../common/image/Dockerfile.trailer >Dockerfile
-   cat Dockerfile.custom.x ../../common/image/Dockerfile.trailer.x >Dockerfile.x
 fi
 
 # -------------------------------------------------------------------------


### PR DESCRIPTION
Removed code related to Docker build package download caches to simplify overall framework and get rid of .x file complexity.   AFAIK nobody uses it and it causes the "real" Dockerfile to be named Dockerfile.x,  involves generation code,  configuration code,  etc.